### PR TITLE
fix: updated environment reference

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -63,7 +63,7 @@ platform :ios do
   
   desc "Deploy to App Store Connect"
   lane :deploy do
-    if ENV["BUILD_NUMBER"].nil? || ENV["BUILD_NUMBER"].empty?
+    if ENV["VERSION_NUMBER"].nil? || ENV["VERSION_NUMBER"].empty?
       UI.important 'nothing to deploy'
       next
     end


### PR DESCRIPTION
This pull request updates the deployment logic in the iOS Fastlane configuration to check for the presence of `VERSION_NUMBER` instead of `BUILD_NUMBER` before proceeding with deployment. This ensures the deployment lane only runs when a version number is specified.

- Deployment logic update:
  * In `fastlane/Fastfile`, the `:deploy` lane now checks for `VERSION_NUMBER` instead of `BUILD_NUMBER` to determine if deployment should proceed.