### PR TITLE
feat: added edit recipe functionality

### DIFF
--- a/Sources/Application/WeeklyMenuApp.swift
+++ b/Sources/Application/WeeklyMenuApp.swift
@@ -45,7 +45,8 @@ private struct RootTabsView: View {
         return TabView(selection: $selectedTab) {
             RecipesView(
                 listVM: RecipesListViewModel(fetchUseCase: fetchUseCase, deleteUseCase: deleteUseCase),
-                makeAddVM: { AddRecipeViewModel(addRecipeUseCase: AddRecipeUseCase(repository: recipeRepo)) }
+                makeAddVM: { recipe in
+                    AddRecipeViewModel(addRecipeUseCase: AddRecipeUseCase(repository: recipeRepo), updateRecipeUseCase: UpdateRecipesUseCase(repository: recipeRepo), existingRecipe: recipe) }
             )
             .tabItem { Label("Recipes", systemImage: "book") }
             .tag(0)

--- a/Sources/UseCases/UpdateRecipesUseCase.swift
+++ b/Sources/UseCases/UpdateRecipesUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  UpdateRecipesUseCase.swift
+//  whattomake
+//
+//  Created by Amish Patel on 20/08/2025.
+//
+
+@MainActor
+struct UpdateRecipesUseCase {
+    
+    private let repository: RecipeRepository
+    
+    init(repository: RecipeRepository) {
+        self.repository = repository
+    }
+
+
+    func execute(recipe: Recipe,
+                 name: String,
+                 notes: String?,
+                 thunbnailBase64: String?,
+                 imageFilename: String?) async throws {
+        recipe.name = name
+        recipe.notes = notes
+        recipe.thumbnailBase64 = thunbnailBase64
+        recipe.imageFilename = imageFilename
+        
+        try await repository.update(recipe)
+    }
+}

--- a/Sources/Views/AddRecipeView.swift
+++ b/Sources/Views/AddRecipeView.swift
@@ -73,7 +73,7 @@ struct AddRecipeView: View {
             }
         }
         .listStyle(.insetGrouped)
-        .navigationTitle("Add Recipe")
+        .navigationTitle(viewModel.isEditing ? "Edit Recipe" : "Add Recipe")
         .scrollDismissesKeyboard(.interactively)
     }
 }

--- a/whattomake.xcodeproj/project.pbxproj
+++ b/whattomake.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3B47D6022E4E3BE000E22A4B /* ImageCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B47D6012E4E3BE000E22A4B /* ImageCodec.swift */; };
 		3B5E9E7E2AE07F9D00293473 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B5E9E7D2AE07F9D00293473 /* Assets.xcassets */; };
 		3B5E9E812AE07F9D00293473 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B5E9E802AE07F9D00293473 /* Preview Assets.xcassets */; };
+		3B64FDF62E56092F001E5915 /* UpdateRecipesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B64FDF52E560927001E5915 /* UpdateRecipesUseCase.swift */; };
 		3BAD929C2E493AA6009DCBAE /* GenerateMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD929A2E4939DB009DCBAE /* GenerateMenuView.swift */; };
 		3BAD929D2E493AA6009DCBAE /* RecipesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD92992E4939D3009DCBAE /* RecipesListView.swift */; };
 		3BAD929E2E493AA6009DCBAE /* AddRecipeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD92982E4939C8009DCBAE /* AddRecipeView.swift */; };
@@ -85,6 +86,7 @@
 		3B5E9E832AE07F9D00293473 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3B5E9E882AE07F9D00293473 /* whattomakeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = whattomakeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B5E9E922AE07F9D00293473 /* whattomakeUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = whattomakeUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3B64FDF52E560927001E5915 /* UpdateRecipesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateRecipesUseCase.swift; sourceTree = "<group>"; };
 		3BAD92802E4937C9009DCBAE /* Recipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Recipe.swift; sourceTree = "<group>"; };
 		3BAD92812E4937D4009DCBAE /* Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Menu.swift; sourceTree = "<group>"; };
 		3BAD92842E493812009DCBAE /* RecipeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeRepository.swift; sourceTree = "<group>"; };
@@ -292,6 +294,7 @@
 		3BAD928B2E49390A009DCBAE /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
+				3B64FDF52E560927001E5915 /* UpdateRecipesUseCase.swift */,
 				3B47D5F62E49662F00E22A4B /* CountRecipesUseCase.swift */,
 				3BAD92AF2E494333009DCBAE /* DeleteRecipeUseCase.swift */,
 				3BAD92922E49393D009DCBAE /* FetchMenusUseCase.swift */,
@@ -488,6 +491,7 @@
 			files = (
 				3BAD929C2E493AA6009DCBAE /* GenerateMenuView.swift in Sources */,
 				3BAFB0D02E538357001B185B /* Colors.swift in Sources */,
+				3B64FDF62E56092F001E5915 /* UpdateRecipesUseCase.swift in Sources */,
 				3BAFB0CF2E537FD0001B185B /* Theme.swift in Sources */,
 				3BAD929D2E493AA6009DCBAE /* RecipesListView.swift in Sources */,
 				3BAFB0CD2E537EBF001B185B /* DesignSystemCanvas.swift in Sources */,


### PR DESCRIPTION
This pull request adds support for editing existing recipes in the app. The main changes include introducing an `UpdateRecipesUseCase`, updating the `AddRecipeViewModel` and related views to handle both adding and editing recipes, and updating the UI to reflect edit mode. Below are the most important changes grouped by theme:

**Editing Recipes Functionality:**

* Added a new `UpdateRecipesUseCase` for updating recipes in the repository. (`Sources/UseCases/UpdateRecipesUseCase.swift`, `whattomake.xcodeproj/project.pbxproj`) [[1]](diffhunk://#diff-1ca084cf98f6772e5420806c20043d33682b3004b427daf16aa3f6a7909f5495R1-R30) [[2]](diffhunk://#diff-95561414e2daaba5c5b9a3b44a14e6b1100249341806667f8494345dc304529eR14) [[3]](diffhunk://#diff-95561414e2daaba5c5b9a3b44a14e6b1100249341806667f8494345dc304529eR89) [[4]](diffhunk://#diff-95561414e2daaba5c5b9a3b44a14e6b1100249341806667f8494345dc304529eR297) [[5]](diffhunk://#diff-95561414e2daaba5c5b9a3b44a14e6b1100249341806667f8494345dc304529eR494)
* Updated `AddRecipeViewModel` to accept an optional existing recipe and update use case, initialize its state from the existing recipe if present, and determine if it is in edit mode. The `saveRecipe` method now updates or adds a recipe as appropriate. (`Sources/ViewModels/AddRecipeViewModel.swift`) [[1]](diffhunk://#diff-7f337e7dfa0ec363ad7167d71440e997f7ff6244329449d90486e7cc6c832f2dR52-R77) [[2]](diffhunk://#diff-7f337e7dfa0ec363ad7167d71440e997f7ff6244329449d90486e7cc6c832f2dR138-R151)

**UI/UX Improvements for Editing:**

* Modified `AddRecipeView` to display "Edit Recipe" or "Add Recipe" as the navigation title based on whether editing or adding. (`Sources/Views/AddRecipeView.swift`)
* Updated `RecipesView` to support opening the add/edit sheet for both new and existing recipes. Tapping a recipe opens it for editing, and the correct view model is constructed for each case. (`Sources/Views/RecipesListView.swift`) [[1]](diffhunk://#diff-b25c67521d13d1e26399bb2d6b204d94855ccd848378960c2a8e6e6320a8199bL13-R14) [[2]](diffhunk://#diff-b25c67521d13d1e26399bb2d6b204d94855ccd848378960c2a8e6e6320a8199bR54-R56) [[3]](diffhunk://#diff-b25c67521d13d1e26399bb2d6b204d94855ccd848378960c2a8e6e6320a8199bL75-R79) [[4]](diffhunk://#diff-b25c67521d13d1e26399bb2d6b204d94855ccd848378960c2a8e6e6320a8199bR98-R117) [[5]](diffhunk://#diff-b25c67521d13d1e26399bb2d6b204d94855ccd848378960c2a8e6e6320a8199bL151-R176) [[6]](diffhunk://#diff-b25c67521d13d1e26399bb2d6b204d94855ccd848378960c2a8e6e6320a8199bL162-R187)

**Integration and Wiring:**

* Updated `RootTabsView` to pass the correct closure for creating `AddRecipeViewModel` instances, supporting both add and edit operations. (`Sources/Application/WeeklyMenuApp.swift`)