### PR TITLE
docs: improve agent and GitHub review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,12 @@ You are helping on an iOS app called "WeeklyMenu". Follow these constraints:
 - Debug menu in debug builds or via -debug-menu arg: clear DB, seed recipes/menu, reset usage, refresh AppState.
 - In UI, render menu rows from snapshot values (day + recipe name) not live model objects to avoid diff crashes.
 - Tests: Swift Testing for units, XCUITest for UI. No mixing of prod/test code unless necessary for debug seeding.
-- When writing commit messages follow conventional commits syntax and prefix message with docs|fix|feat|chore|style|refactor|perf|test and use ! if there are breaking changes for example "feat!: this is a breaking change"
+- When writing commit messages follow Conventional Commits syntax: `<type>[optional scope][optional !]: <description>`
+- Allowed types in this repo are `docs|fix|feat|chore|style|refactor|perf|test`
+- Use `feat` for new features and `fix` for bug fixes; these are the main types with SemVer meaning in the Conventional Commits spec
+- Use `!` immediately before `:` to mark a breaking change, for example `feat!: remove legacy menu flow`
+- A `BREAKING CHANGE:` footer may also be used to explain breaking impact in more detail
+- Scope is optional and should only be used when it adds real clarity; most commits should omit it
+- If scope is used, keep it short and concrete, for example `fix(menu): handle empty state`
 - When writing documentation for code use swift standard DocC format, keep it clear and concise and where applicable give example useage 
 - When code reviewing look out for common spelling mistakes and obvious errors
-

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,20 +1,179 @@
-You are helping on an iOS app called "WeeklyMenu". Follow these constraints:
-- iOS app in Swift, SwiftUI UI, SwiftData persistence, Swift Concurrency async/await only.
-- No Combine, no force-unwraps, verbose camelCase names.
-- Use SOLID principles, clean architecture with Use Cases + Repository pattern.
-- Recipes: name (required), notes (optional), optional photo via PhotosPicker. No ingredients.
-- Menu generation: disabled unless ≥7 recipes. User can select any days Mon–Sun. Increments recipe usageCount on generate.
-- AppState: @Observable, injected via environment, has refreshCounter to trigger view reloads.
-- Accessibility IDs required on all controls for UI tests (recipesList, emptyRecipesView, addRecipeButton, recipeNameField, notesField, choosePhotoButton, saveRecipeButton, toggleDay_<Day>, generateMenuButton, menuItem_<Day>, menuRecipesRequirementMessage, menuValidationMessage, debug_*).
-- Debug menu in debug builds or via -debug-menu arg: clear DB, seed recipes/menu, reset usage, refresh AppState.
-- In UI, render menu rows from snapshot values (day + recipe name) not live model objects to avoid diff crashes.
-- Tests: Swift Testing for units, XCUITest for UI. No mixing of prod/test code unless necessary for debug seeding.
-- When writing commit messages follow Conventional Commits syntax: `<type>[optional scope][optional !]: <description>`
-- Allowed types in this repo are `docs|fix|feat|chore|style|refactor|perf|test`
-- Use `feat` for new features and `fix` for bug fixes; these are the main types with SemVer meaning in the Conventional Commits spec
-- Use `!` immediately before `:` to mark a breaking change, for example `feat!: remove legacy menu flow`
-- A `BREAKING CHANGE:` footer may also be used to explain breaking impact in more detail
-- Scope is optional and should only be used when it adds real clarity; most commits should omit it
-- If scope is used, keep it short and concrete, for example `fix(menu): handle empty state`
-- When writing documentation for code use swift standard DocC format, keep it clear and concise and where applicable give example useage 
-- When code reviewing look out for common spelling mistakes and obvious errors
+You are reviewing pull requests for the `what-to-make` repository.
+
+This file is for code review only.
+
+Your job is to identify real defects, regressions, risky changes, and missing coverage. Do not rewrite the codebase to match personal preferences. Do not generate low-value review noise.
+
+## Review contract
+
+You must prioritise review in this order:
+
+1. Functional regressions
+2. Data-loss or persistence risks
+3. SwiftUI state-management or concurrency defects
+4. Architecture boundary violations
+5. Accessibility or UI test regressions
+6. Missing tests for changed behavior
+7. Maintainability issues that create real future risk
+
+You must not prioritise:
+
+- formatting preferences
+- personal style opinions
+- speculative cleanup
+- broad refactors outside the scope of the diff
+- generic requests for more comments or documentation
+
+If there are no actionable findings, say so clearly.
+
+## Project facts you must preserve
+
+This repository is an iOS app built with:
+
+- Swift
+- SwiftUI
+- SwiftData
+- Swift Concurrency (`async`/`await`)
+- Swift Testing for unit tests
+- XCUITest for UI tests
+
+Current product rules:
+
+- Recipe `name` is required
+- `notes` are optional
+- photos are optional
+- there is no ingredient list in the current product
+- menu generation requires at least 7 recipes
+- users can select any subset of Mon-Sun
+- generating a menu increments `usageCount`
+
+## Architecture rules
+
+The intended structure is:
+
+- Views are light and mostly declarative
+- View models own UI-facing state
+- Use cases contain application logic
+- Repositories isolate SwiftData persistence details
+
+You should flag changes that:
+
+- move business logic into SwiftUI views without good reason
+- bypass use case or repository boundaries without clear justification
+- mix persistence logic directly into UI code
+- add production complexity only to support tests
+
+Do not request an architectural rewrite if the existing pattern is still being followed adequately.
+
+## Concurrency and SwiftUI rules
+
+This project uses Swift Concurrency only.
+
+You must flag changes that:
+
+- introduce Combine
+- violate actor isolation
+- mutate observable state unsafely
+- rely on fire-and-forget tasks that can leave UI state inconsistent
+- create SwiftUI diffing, refresh, or lifecycle instability
+
+Pay extra attention to:
+
+- `@Observable` view models
+- `.task`
+- `Form`
+- async loading flows
+- error-state transitions
+
+Generated menu UI must continue to render from stable snapshot values such as day + recipe name, not from live mutable model state.
+
+## Persistence and storage rules
+
+SwiftData is the source of truth for app data.
+
+Review model, repository, and image-storage changes carefully.
+
+Current image design:
+
+- recipe thumbnails are stored inline as Base64 on the model
+- original full-resolution images are stored on disk by filename
+
+You must flag changes that could:
+
+- lose or corrupt saved recipes or menus
+- orphan image files
+- break filename-to-file consistency
+- blur the separation between inline thumbnail data and on-disk originals
+- silently change persistence semantics
+
+## UI test contract
+
+Accessibility identifiers are part of the app’s contract with UI tests.
+
+Treat identifier changes as breaking unless the tests are updated in the same pull request.
+
+Important identifiers:
+
+- `recipesList`
+- `emptyRecipesView`
+- `addRecipeButton`
+- `recipeNameField`
+- `notesField`
+- `choosePhotoButton`
+- `saveRecipeButton`
+- `toggleDay_<Day>`
+- `generateMenuButton`
+- `menuItem_<Day>`
+- `menuRecipesRequirementMessage`
+- `menuValidationMessage`
+- `debug_*`
+
+Protect these launch-argument test hooks:
+
+- `-ui-tests-blank`
+- `-ui-tests-seeded`
+- `-debug-menu`
+
+## Repo-specific review rules
+
+You should flag changes that conflict with these expectations:
+
+- no force unwraps unless strongly justified
+- use clear camelCase naming
+- prefer Swift Concurrency over older async patterns
+- preserve the current recipe and menu product rules
+- do not reintroduce stale ingredient-related logic, identifiers, comments, or tests
+
+The repo currently has naming inconsistencies such as `whattomake` and `ForkPlan`. Ignore that unless a change introduces a real build, import, packaging, or test problem.
+
+## Testing rules
+
+When behavior changes, tests should usually change too.
+
+You should call out missing or weak coverage when a diff affects:
+
+- validation rules
+- menu generation logic
+- recipe persistence
+- image handling
+- accessibility identifiers
+- launch-argument behavior
+- view model state transitions
+- error handling paths
+
+Missing tests are especially important when the changed behavior is user-visible, persistence-related, or async.
+
+## Review output rules
+
+When writing review feedback:
+
+- lead with findings, not with a summary
+- report only actionable findings
+- order findings by severity
+- cite the specific file and line or code region
+- explain the concrete risk
+- tie the risk to this app’s behavior when possible
+- mention missing tests when relevant
+- keep comments concise
+
+If no actionable findings exist, say that explicitly and mention any residual risk briefly.

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,275 @@
+# AGENT.md
+
+## Project overview
+
+`what-to-make` is an iOS app built with SwiftUI, SwiftData, and Swift Concurrency. The app lets users save recipes and generate a weekly menu from those saved recipes.
+
+The codebase follows a clean architecture style:
+
+- `Sources/Application`: app entry point, store bootstrapping, root navigation
+- `Sources/Models`: SwiftData models plus image encoding/storage helpers
+- `Sources/Repositories`: repository protocols and SwiftData-backed implementations
+- `Sources/UseCases`: application logic
+- `Sources/ViewModels`: `@Observable` UI state and orchestration
+- `Sources/Views`: SwiftUI screens
+- `Sources/DesignSystem`: shared UI styling and components
+- `Tests`: unit tests using Swift Testing
+- `UITests`: UI tests using XCUITest
+- `TestPlans`: Xcode test plans for unit and UI test runs
+- `fastlane`: CI/deployment automation
+- `.github/workflows`: pull request and merged-branch automation
+- `docs`: project site/docs content
+- `context`: extra engineering context used to guide agents
+
+## Local setup
+
+Requirements:
+
+- macOS with Xcode 15+ for local development
+- iOS 17+ simulator/runtime
+- Ruby/Bundler for Fastlane-based automation
+
+Open the project with:
+
+```bash
+open whattomake.xcworkspace
+```
+
+Useful install/setup commands:
+
+```bash
+bundle install
+bundle exec fastlane --version
+```
+
+Notes:
+
+- The shared Xcode scheme is `whattomake`.
+- The built app product in the shared scheme is currently `ForkPlan.app`, so do not assume the app bundle name matches the repository name.
+- `fastlane/Fastfile` currently selects `/Applications/Xcode_16.4.app` explicitly in CI-oriented lanes.
+
+## Build and test commands
+
+Run unit tests with the dedicated test plan:
+
+```bash
+xcodebuild \
+  -workspace whattomake.xcworkspace \
+  -scheme whattomake \
+  -testPlan UnitTestsPlan \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  test
+```
+
+Run UI tests with the UI test plan:
+
+```bash
+xcodebuild \
+  -workspace whattomake.xcworkspace \
+  -scheme whattomake \
+  -testPlan UITestsPlan \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  test
+```
+
+Run the Fastlane unit-test lane used by CI:
+
+```bash
+WORKSPACE="$PWD" \
+WORKSPACE_FILENAME="whattomake.xcworkspace" \
+SCHEME="whattomake" \
+TEST_PLAN="UnitTestsPlan" \
+bundle exec fastlane runUnitTests
+```
+
+Important test/CI details:
+
+- `TestPlans/UnitTestsPlan.xctestplan` runs `whattomakeTests`
+- `TestPlans/UITestsPlan.xctestplan` runs `whattomakeUITests`
+- PR workflow runs on `macos-15`
+- PR workflow validates pull request naming and runs `fastlane runUnitTests`
+- Merged-branch workflow handles versioning and TestFlight deployment
+
+## Architecture and runtime behavior
+
+Primary patterns and constraints:
+
+- SwiftUI for UI
+- SwiftData for persistence
+- Swift Concurrency (`async`/`await`) only
+- `@Observable` view models
+- Use Cases + Repository pattern
+- Avoid Combine
+- Avoid force unwraps
+
+Runtime store behavior from `Sources/Application/WeeklyMenuApp.swift`:
+
+- Normal app launches use a persistent `ModelContainer`
+- UI test launches can switch to in-memory stores via launch arguments
+- `-ui-tests-blank` uses an in-memory empty store
+- `-ui-tests-seeded` uses an in-memory seeded store
+
+Current seeded UI-test mode inserts 8 recipes so the weekly menu flow satisfies the minimum recipe requirement.
+
+## Data and storage
+
+SwiftData models:
+
+- `Sources/Models/Recipe.swift`
+- `Sources/Models/Menu.swift`
+
+Persisted recipe fields include:
+
+- `name`
+- `notes`
+- `usageCount`
+- `thumbnailBase64`
+- `imageFilename`
+
+Persisted menu fields include:
+
+- `generatedDate`
+- `days`
+- `recipes`
+
+Image storage behavior from `Sources/Models/ImageCodec.swift`:
+
+- Thumbnail images are stored inline on the `Recipe` model as Base64 JPEG strings
+- Original full-resolution images are stored on disk via `ImageStore`
+- The on-disk image directory is the app container's `Application Support/Images`
+- If `Application Support` is unavailable, image storage falls back to a temporary `Images` directory
+
+When editing image-related features, preserve the split between:
+
+- lightweight thumbnail data in SwiftData
+- original image files on disk referenced by filename
+
+## Project conventions
+
+Code conventions already documented in the repo:
+
+- Use SOLID principles and clean boundaries
+- Keep views light and put orchestration in view models/use cases
+- Use verbose camelCase naming
+- Prefer DocC-style documentation comments for code docs
+- Keep accessibility identifiers stable for UI tests
+
+Feature constraints that show up across docs/tests:
+
+- Recipe name is required
+- Notes are optional
+- Photos are optional
+- There is no ingredient list in the current version
+- Menu generation requires at least 7 recipes
+- Users can select any subset of days from Mon-Sun
+- Generating a menu increments `usageCount`
+- Menu rows should render from snapshot values, not live mutable model objects
+
+## Accessibility and test hooks
+
+UI tests rely on accessibility identifiers such as:
+
+- `recipesList`
+- `emptyRecipesView`
+- `addRecipeButton`
+- `recipeNameField`
+- `notesField`
+- `choosePhotoButton`
+- `saveRecipeButton`
+- `toggleDay_<Day>`
+- `generateMenuButton`
+- `menuItem_<Day>`
+- `menuRecipesRequirementMessage`
+- `menuValidationMessage`
+- `debug_*`
+
+Debug/test launch behavior:
+
+- `-debug-menu` enables the debug menu outside normal debug-only visibility
+- Debug actions include clearing data, seeding data, resetting usage counts, and refreshing app state
+
+## Automation and release flow
+
+CI and release-related files:
+
+- `.github/workflows/pull-request.yml`
+- `.github/workflows/merged.yml`
+- `fastlane/Fastfile`
+- `sonar-project.properties`
+- `scripts/xccov-to-sonarqube-generic.sh`
+
+Important automation details:
+
+- SonarCloud analysis is configured for `Sources` and `Tests`
+- Fastlane `runUnitTests` generates an `.xcresult` bundle and converts coverage for SonarCloud
+- Fastlane `deploy` increments the build number, updates the marketing version, builds the app, and uploads to TestFlight
+
+## Commit and review guidance
+
+The repo includes a `hooks/commit-msg` hook enforcing Conventional Commits. Use commit messages in this shape:
+
+```text
+docs: update AGENT.md
+fix: correct menu validation logic
+feat!: remove deprecated recipe flow
+```
+
+General format:
+
+```text
+<type>[optional scope][optional !]: <description>
+```
+
+Guidance:
+
+- Keep the type lowercase
+- Keep the description short and specific
+- Use `!` immediately before `:` for a breaking change
+- Use a `BREAKING CHANGE:` footer when extra detail is needed
+- Scope is optional and should usually be omitted unless it adds useful clarity
+- If you use scope, keep it to a short noun for a real area of the codebase, for example `fix(menu): handle empty state`
+
+Allowed prefixes enforced by the hook:
+
+- `docs`
+- `fix`
+- `feat`
+- `chore`
+- `style`
+- `refactor`
+- `perf`
+- `test`
+
+Meaning of the common types used in this repo:
+
+- `feat`: a new user-facing or developer-facing feature
+- `fix`: a bug fix
+- `docs`: documentation-only changes
+- `chore`: maintenance or project housekeeping that is not a feature/fix
+- `style`: formatting or stylistic cleanup with no behavioral change
+- `refactor`: code restructuring with no intended behavior change
+- `perf`: a change intended to improve performance
+- `test`: adding or updating tests
+
+Practical advice:
+
+- Prefer a single clear type over trying to encode everything in one commit
+- If a change mixes unrelated concerns, split it into multiple commits when practical
+- Most commits do not need scope
+- Good examples: `fix: prevent duplicate seeded recipes`, `docs: clarify local setup`, `test: cover menu validation`
+- Use scope sparingly: `feat(images): persist original photo filenames`
+
+## Agent guidance for edits
+
+Before making changes:
+
+- Check whether the change affects `Sources`, `Tests`, `UITests`, or CI automation together
+- Preserve repository pattern and use case boundaries
+- Update or add tests when behavior changes
+- Keep UI test identifiers intact unless the tests are updated at the same time
+
+When working on persistence or images:
+
+- Be careful not to break the persistent SwiftData model
+- Preserve `ImageStore` file-location assumptions
+- Treat on-disk images as best-effort local storage, not synced canonical data


### PR DESCRIPTION
## Summary
- add a root `AGENT.md` with project structure, setup, storage, testing, CI, and repo conventions
- clarify Conventional Commits guidance for agents
- replace the GitHub instruction file with stricter review-only guidance for GitHub code review agents

## Testing
- not run (documentation-only changes)