### PR TITLE
test: add in-memory ModelContainer fixtures for unit tests

### DIFF
--- a/Tests/Fixtures/TestModelContainer.swift
+++ b/Tests/Fixtures/TestModelContainer.swift
@@ -1,0 +1,67 @@
+//
+//  TestModelContainer.swift
+//  whattomake
+//
+
+import Foundation
+import SwiftData
+@testable import ForkPlan
+
+/// Creates an in-memory SwiftData container for unit and snapshot tests.
+///
+/// - Throws: If `ModelContainer` initialization fails.
+func makeTestContainer() throws -> ModelContainer {
+    let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(
+        for: Recipe.self, Menu.self,
+        configurations: configuration
+    )
+}
+
+/// Seeds recipes into the context and saves.
+///
+/// - Parameters:
+///   - context: The model context to insert into.
+///   - count: Number of recipes (default 8 — satisfies the ≥ 7 product rule).
+///   - namePrefix: Prefix for generated names (e.g. "Test Recipe 1").
+///   - notesEvery: When set, every Nth recipe gets a note (default 2).
+///   - usageCount: Initial usage count for each recipe.
+/// - Returns: Inserted recipes sorted by name ascending.
+func seedRecipes(
+    in context: ModelContext,
+    count: Int = 8,
+    namePrefix: String = "Test Recipe",
+    notesEvery: Int? = 2,
+    usageCount: Int = 0
+) throws -> [Recipe] {
+    for index in 1...count {
+        let recipe = Recipe(
+            name: "\(namePrefix) \(index)",
+            notes: notesEvery.map { index.isMultiple(of: $0) ? "Note \(index)" : nil } ?? nil,
+            usageCount: usageCount
+        )
+        context.insert(recipe)
+    }
+    try context.save()
+    return try context.fetch(FetchDescriptor<Recipe>(sortBy: [SortDescriptor(\.name)]))
+}
+
+/// Seeds a menu snapshot linking existing recipes to day IDs.
+///
+/// - Parameters:
+///   - context: The model context to insert into.
+///   - days: Ordered day identifiers (e.g. `["Mon", "Wed"]`).
+///   - recipes: Recipes corresponding to days (caller supplies — does not auto-create).
+///   - generatedDate: Menu generation timestamp.
+/// - Returns: The inserted menu after save.
+func seedMenu(
+    in context: ModelContext,
+    days: [String],
+    recipes: [Recipe],
+    generatedDate: Date = Date()
+) throws -> Menu {
+    let menu = Menu(generatedDate: generatedDate, days: days, recipes: recipes)
+    context.insert(menu)
+    try context.save()
+    return menu
+}

--- a/Tests/TestModelContainerTests.swift
+++ b/Tests/TestModelContainerTests.swift
@@ -1,0 +1,34 @@
+//
+//  TestModelContainerTests.swift
+//  whattomake
+//
+
+@testable import ForkPlan
+import SwiftData
+import Testing
+
+@MainActor
+@Suite
+struct TestModelContainerTests {
+    @Test
+    func makeTestContainerSeedsRecipesAndMenu() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let recipes = try seedRecipes(in: context, count: 8)
+        let menu = try seedMenu(
+            in: context,
+            days: ["Mon", "Wed"],
+            recipes: Array(recipes.prefix(2))
+        )
+
+        let storedRecipes = try context.fetch(FetchDescriptor<Recipe>())
+        let storedMenus = try context.fetch(FetchDescriptor<Menu>())
+
+        #expect(storedRecipes.count == 8)
+        #expect(storedMenus.count == 1)
+        #expect(menu.days == ["Mon", "Wed"])
+        #expect(menu.recipes.count == 2)
+        #expect(recipes.count == 8)
+    }
+}

--- a/whattomake.xcodeproj/project.pbxproj
+++ b/whattomake.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		3BFF4A8D2E50B2C300022454 /* AddRecipeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFF4A7B2E50B2C300022454 /* AddRecipeViewModelTests.swift */; };
 		3BFF4A8F2E50B30B00022454 /* GenerateMenuUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFF4A8E2E50B30100022454 /* GenerateMenuUseCaseTests.swift */; };
 		3C0A00022E60A00100000002 /* SnapshotTestingSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00012E60A00100000001 /* SnapshotTestingSmokeTests.swift */; };
+		3C0A00112E60B00300000002 /* TestModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00102E60B00300000001 /* TestModelContainer.swift */; };
+		3C0A00132E60B00300000004 /* TestModelContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00122E60B00300000003 /* TestModelContainerTests.swift */; };
 		3C0A00052E60A00100000005 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 3C0A00042E60A00100000004 /* SnapshotTesting */; };
 /* End PBXBuildFile section */
 
@@ -134,6 +136,8 @@
 		3BFF4A832E50B2C300022454 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
 		3BFF4A8E2E50B30100022454 /* GenerateMenuUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateMenuUseCaseTests.swift; sourceTree = "<group>"; };
 		3C0A00012E60A00100000001 /* SnapshotTestingSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTestingSmokeTests.swift; sourceTree = "<group>"; };
+		3C0A00102E60B00300000001 /* TestModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModelContainer.swift; sourceTree = "<group>"; };
+		3C0A00122E60B00300000003 /* TestModelContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModelContainerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -220,6 +224,8 @@
 				3BFF4A822E50B2C300022454 /* RecipesListViewModelTests.swift */,
 				3BFF4A832E50B2C300022454 /* Tests.swift */,
 				3C0A00012E60A00100000001 /* SnapshotTestingSmokeTests.swift */,
+				3C0A00122E60B00300000003 /* TestModelContainerTests.swift */,
+				3C0A00142E60B00300000005 /* Fixtures */,
 				3BAD92882E4938B6009DCBAE /* Mocks */,
 			);
 			path = Tests;
@@ -282,6 +288,14 @@
 				3BAD92892E4938B8009DCBAE /* MockRecipeRepository.swift */,
 			);
 			path = Mocks;
+			sourceTree = "<group>";
+		};
+		3C0A00142E60B00300000005 /* Fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				3C0A00102E60B00300000001 /* TestModelContainer.swift */,
+			);
+			path = Fixtures;
 			sourceTree = "<group>";
 		};
 		3BAD928B2E49390A009DCBAE /* UseCases */ = {
@@ -537,6 +551,8 @@
 				3BFF4A8C2E50B2C300022454 /* RecipesListViewModelTests.swift in Sources */,
 				3BFF4A8D2E50B2C300022454 /* AddRecipeViewModelTests.swift in Sources */,
 				3C0A00022E60A00100000002 /* SnapshotTestingSmokeTests.swift in Sources */,
+				3C0A00112E60B00300000002 /* TestModelContainer.swift in Sources */,
+				3C0A00132E60B00300000004 /* TestModelContainerTests.swift in Sources */,
 				3BAD92B32E49449C009DCBAE /* MockMenuRepository.swift in Sources */,
 				3BAD92B42E49449C009DCBAE /* MockRecipeRepository.swift in Sources */,
 			);


### PR DESCRIPTION
## Summary

- Add `makeTestContainer()`, `seedRecipes`, and `seedMenu` in `Tests/Fixtures/TestModelContainer.swift` for in-memory SwiftData setup without launch arguments or mocks.
- Add `TestModelContainerTests` to verify container creation, recipe seeding, and menu snapshot persistence.
- Register fixture and test files in `whattomakeTests` via `project.pbxproj` (`Fixtures` PBXGroup).

## Test plan

- [x] `xcodebuild -workspace whattomake.xcworkspace -scheme whattomake -testPlan UnitTestsPlan -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test`