### PR TITLE
docs: document menu delete semantics and empty state copy

### DIFF
--- a/Sources/Helpers/MenuEmptyStateCopy.swift
+++ b/Sources/Helpers/MenuEmptyStateCopy.swift
@@ -1,0 +1,15 @@
+//
+//  MenuEmptyStateCopy.swift
+//  whattomake
+//
+//  Created by Amish Patel on 15/06/2026.
+//
+
+import Foundation
+
+/// UX copy constants for the Generate Menu screen empty state.
+enum MenuEmptyStateCopy {
+    /// Coaching message when no menu exists yet (UX-DR3).
+    /// Epic 1 Story 1.2 wires this into `GenerateMenuView` via `@Query`.
+    static let message = "No menu yet — select days and tap Generate"
+}

--- a/Sources/Models/Menu.swift
+++ b/Sources/Models/Menu.swift
@@ -14,6 +14,10 @@ import SwiftData
 /// at the time of generation. The UI should render rows from this snapshot
 /// (day + recipe name) to avoid diffing against live, mutable models.
 ///
+/// **Delete semantics:** ``recipes`` uses ``Relationship/deleteRule`` `.nullify`.
+/// Deleting a menu snapshot (e.g. during delete-before-insert regenerate) removes the
+/// ``Menu`` record only — linked ``Recipe`` records remain in the library.
+///
 /// Example
 /// ```swift
 /// let menu = Menu(days: ["Mon", "Wed"], recipes: [r1, r2])
@@ -27,6 +31,10 @@ final class Menu {
     /// The ordered list of day identifiers (e.g., "Mon", "Tue").
     var days: [String]
     /// The recipes chosen for the corresponding ``days`` entries.
+    ///
+    /// Delete rule `.nullify`: removing this menu does not delete recipes.
+    /// The menu holds references to recipes as they existed at generation time.
+    @Relationship(deleteRule: .nullify)
     var recipes: [Recipe]
 
     /// Creates a new menu snapshot.

--- a/whattomake.xcodeproj/project.pbxproj
+++ b/whattomake.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		3C0A00022E60A00100000002 /* SnapshotTestingSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00012E60A00100000001 /* SnapshotTestingSmokeTests.swift */; };
 		3C0A00112E60B00300000002 /* TestModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00102E60B00300000001 /* TestModelContainer.swift */; };
 		3C0A00132E60B00300000004 /* TestModelContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00122E60B00300000003 /* TestModelContainerTests.swift */; };
+		3C0A00162E60C00400000002 /* MenuEmptyStateCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00152E60C00400000001 /* MenuEmptyStateCopy.swift */; };
 		3C0A00052E60A00100000005 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 3C0A00042E60A00100000004 /* SnapshotTesting */; };
 /* End PBXBuildFile section */
 
@@ -138,6 +139,7 @@
 		3C0A00012E60A00100000001 /* SnapshotTestingSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTestingSmokeTests.swift; sourceTree = "<group>"; };
 		3C0A00102E60B00300000001 /* TestModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModelContainer.swift; sourceTree = "<group>"; };
 		3C0A00122E60B00300000003 /* TestModelContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModelContainerTests.swift; sourceTree = "<group>"; };
+		3C0A00152E60C00400000001 /* MenuEmptyStateCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuEmptyStateCopy.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -196,6 +198,7 @@
 				3BAD928B2E49390A009DCBAE /* UseCases */,
 				3BAD92832E4937F6009DCBAE /* Repositories */,
 				3B5E9EA72AE08B3F00293473 /* Models */,
+				3C0A00172E60C00400000003 /* Helpers */,
 				3B5E9EA62AE0853000293473 /* Application */,
 				3BAFB0BB2E537D0C001B185B /* DesignSystem */,
 			);
@@ -296,6 +299,14 @@
 				3C0A00102E60B00300000001 /* TestModelContainer.swift */,
 			);
 			path = Fixtures;
+			sourceTree = "<group>";
+		};
+		3C0A00172E60C00400000003 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				3C0A00152E60C00400000001 /* MenuEmptyStateCopy.swift */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 		3BAD928B2E49390A009DCBAE /* UseCases */ = {
@@ -528,6 +539,7 @@
 				3BAD92AA2E493AA6009DCBAE /* MenuRepository.swift in Sources */,
 				3BAD92AB2E493AA6009DCBAE /* RecipeRepository.swift in Sources */,
 				3BAD92AC2E493AA6009DCBAE /* Menu.swift in Sources */,
+				3C0A00162E60C00400000002 /* MenuEmptyStateCopy.swift in Sources */,
 				3BAD92AD2E493AA6009DCBAE /* Recipe.swift in Sources */,
 				3BAFB0C52E537D72001B185B /* Layout.swift in Sources */,
 				3BAD92AE2E493AA6009DCBAE /* WeeklyMenuApp.swift in Sources */,


### PR DESCRIPTION
## Summary 

This PR completes Story 0.4 by documenting how the `Menu` model handles deletes and introducing the canonical empty-state copy for the Generate Menu screen. `Menu.recipes` now has an explicit `@Relationship(deleteRule: .nullify)` annotation and doc comments explaining that removing a menu snapshot (for example during delete-before-insert regenerate) only deletes the `Menu` record — linked `Recipe` entries stay in the library.

It also adds `MenuEmptyStateCopy` under `Sources/Helpers/` with the UX-approved message: "No menu yet — select days and tap Generate." That constant isn't wired into the UI yet; Epic 1 Story 1.2 will connect it in `GenerateMenuView` via `@Query`. No runtime behavior changes are expected in this PR.