### PR TITLE
ci: pin test simulator and document snapshot workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    name: Build and Test default scheme using any available iPhone simulator
+    name: Build and test on pinned iPhone 17 Pro simulator
     if: github.event.pull_request.draft == false
     runs-on: macos-26
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ bundle install
 
 ## Tests
 
+Unit and future snapshot tests run on the pinned **iPhone 17 Pro** simulator. See [`docs/project-context.md`](docs/project-context.md) for the snapshot re-record workflow.
+
 ```bash
 # Unit tests
 xcodebuild \

--- a/Tests/__Snapshots__/iPhone17Pro-iOS26/README.md
+++ b/Tests/__Snapshots__/iPhone17Pro-iOS26/README.md
@@ -1,0 +1,38 @@
+# Snapshot baselines — iPhone17Pro-iOS26
+
+Committed reference PNGs for visual regression testing (Epic 2+).
+
+## Device slug convention
+
+`iPhone17Pro-iOS26` = **iPhone 17 Pro** simulator + **iOS 26** deployment/runtime (spaces removed, hyphen-separated).
+
+## Current status
+
+No PNG baselines yet. Reference images will be recorded in Epic 2 Story 2.1 (`RecipeSnapshotTests`, `MenuSnapshotTests`).
+
+Do not commit ad-hoc PNGs outside the Epic 2 snapshot workflow.
+
+## Recording baselines (local only)
+
+Re-record on the pinned **iPhone 17 Pro** simulator after UI changes:
+
+```bash
+RECORD_SNAPSHOTS=1 xcodebuild -workspace whattomake.xcworkspace -scheme whattomake \
+  -testPlan UnitTestsPlan \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test
+```
+
+## Baseline settings
+
+| Setting | Required value |
+|---------|----------------|
+| Color scheme | Light |
+| Locale | `en_US` |
+| Dynamic Type | Standard (default / `.large`) |
+| Simulator | iPhone 17 Pro |
+
+## CI
+
+Never set `RECORD_SNAPSHOTS=1` in GitHub Actions. CI runs snapshot tests in compare-only mode on the pinned simulator.
+
+See `docs/project-context.md` → Testing Rules → Snapshot tests for full workflow documentation.

--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -141,7 +141,7 @@ Sources/
   DesignSystem/  unchanged
 Tests/
   Fixtures/      makeTestContainer() (Story 0.3)
-  __Snapshots__/ iPhone17Pro-iOS26/ (Story 0.5+)
+  __Snapshots__/ iPhone17Pro-iOS26/ (see Tests/__Snapshots__/iPhone17Pro-iOS26/README.md)
 ```
 
 ### Testing Rules
@@ -157,9 +157,24 @@ Tests/
 **Snapshot tests (`Tests/`):**
 
 - Library: Point-Free **swift-snapshot-testing** (`import SnapshotTesting`); linked to `whattomakeTests` only.
-- Baselines: `Tests/__Snapshots__/iPhone17Pro-iOS26/` — light mode, fixed locale, standard Dynamic Type.
+- Baselines: `Tests/__Snapshots__/iPhone17Pro-iOS26/` — see [`Tests/__Snapshots__/iPhone17Pro-iOS26/README.md`](../Tests/__Snapshots__/iPhone17Pro-iOS26/README.md) for slug convention and recording workflow.
 - Re-record locally only: `RECORD_SNAPSHOTS=1` — **never** in CI.
 - Snapshot tests seed data directly via `makeTestContainer()` — no launch arguments.
+
+**Device slug mapping:**
+
+| Simulator destination | Device slug folder |
+|-----------------------|-------------------|
+| `platform=iOS Simulator,name=iPhone 17 Pro` | `Tests/__Snapshots__/iPhone17Pro-iOS26/` |
+
+**Baseline recording settings** (Epic 2 snapshot tests must apply):
+
+| Setting | Required value | Notes |
+|---------|----------------|-------|
+| Color scheme | Light | `.preferredColorScheme(.light)` or `@Environment(\.colorScheme)` override in test host |
+| Locale | `en_US` | Set via test `Locale` environment or view modifier — pick one approach and document for Epic 2 |
+| Dynamic Type | Standard (`.large` / default) | Do not use accessibility sizes in baseline snapshots |
+| Simulator | iPhone 17 Pro | Must match CI Fastfile destination |
 
 **Removed (do not reintroduce):**
 
@@ -204,13 +219,13 @@ RECORD_SNAPSHOTS=1 xcodebuild -workspace whattomake.xcworkspace -scheme whattoma
   -testPlan UnitTestsPlan \
   -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test
 
-# CI-equivalent via Fastlane
+# CI-equivalent via Fastlane (pinned iPhone 17 Pro via PINNED_TEST_DESTINATION in Fastfile)
 WORKSPACE="$PWD" WORKSPACE_FILENAME="whattomake.xcworkspace" \
 SCHEME="whattomake" TEST_PLAN="UnitTestsPlan" \
 bundle exec fastlane runUnitTests
 ```
 
-**CI/release:** PR checks in `.github/workflows/pull-request.yml` (Conventional Commit title validation + unit tests via `fastlane runUnitTests` on `macos-26`, using the runner's preinstalled Fastlane). Merged-branch workflow in `.github/workflows/merged.yml` runs [Oliver-Binns/Versioning](https://github.com/Oliver-Binns/Versioning) to create GitHub releases/tags from commit semantics; TestFlight deploy runs only when Versioning produces a new release (skips `chore`/`docs`/`ci`/etc. merges to save CI minutes). **Two version tracks:** GitHub release semver is automated; App Store `MARKETING_VERSION` is set manually in Xcode before release; Fastlane reads marketing version from the project and increments `CURRENT_PROJECT_VERSION` from the latest TestFlight build for that marketing version.
+**CI/release:** PR checks in `.github/workflows/pull-request.yml` (Conventional Commit title validation + unit tests via `fastlane runUnitTests` on `macos-26`, using the runner's preinstalled Fastlane). The `runUnitTests` lane pins the test destination to **iPhone 17 Pro** via `PINNED_TEST_DESTINATION` in `fastlane/Fastfile`. Merged-branch workflow in `.github/workflows/merged.yml` runs [Oliver-Binns/Versioning](https://github.com/Oliver-Binns/Versioning) to create GitHub releases/tags from commit semantics; TestFlight deploy runs only when Versioning produces a new release (skips `chore`/`docs`/`ci`/etc. merges to save CI minutes). **Two version tracks:** GitHub release semver is automated; App Store `MARKETING_VERSION` is set manually in Xcode before release; Fastlane reads marketing version from the project and increments `CURRENT_PROJECT_VERSION` from the latest TestFlight build for that marketing version.
 
 **Commits:** Conventional Commits enforced by `hooks/commit-msg`.
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,6 +18,7 @@ platform :ios do
   PROJECT_NAME = "whattomake.xcodeproj"
   APP_IDENTIFIER = "amishpatel.whattomake"
   PROVISIONING_PROFILE_NAME = "ForkPlan App Store"
+  PINNED_TEST_DESTINATION = "platform=iOS Simulator,name=iPhone 17 Pro"
 
   desc "Run unit test and upload test coverage"
   lane :runUnitTests do
@@ -30,6 +31,8 @@ platform :ios do
       workspace: ENV["WORKSPACE_FILENAME"],
       scheme: ENV["SCHEME"],
       testplan: ENV["TEST_PLAN"],
+      destination: PINNED_TEST_DESTINATION,
+      ensure_devices_found: true,
       result_bundle: true,
     )
   end


### PR DESCRIPTION
## Summary

Pins the PR unit-test lane to the iPhone 17 Pro simulator by adding a shared Fastlane destination constant and using it from `runUnitTests` with fail-fast simulator lookup. The PR workflow name now reflects the pinned simulator, keeping CI behavior aligned with the documented local `xcodebuild` command.

Establishes the `Tests/__Snapshots__/iPhone17Pro-iOS26/` baseline directory with README guidance for future snapshot recording, including local-only `RECORD_SNAPSHOTS=1`, light mode, `en_US` locale, and standard Dynamic Type. Updates `README.md` and `docs/project-context.md` to document the snapshot workflow and Fastlane pin; no production source or snapshot PNG baselines are included.