### PR TITLE
refactor(app): simplify WeeklyMenuApp composition root

### DIFF
--- a/Sources/Application/WeeklyMenuApp.swift
+++ b/Sources/Application/WeeklyMenuApp.swift
@@ -12,60 +12,30 @@ import SwiftData
 @main
 struct WeeklyMenuApp: App {
     var body: some Scene {
+        let mode = StoreMode.current()
         WindowGroup {
-            let mode = StoreMode.current()
-            if let container = StoreFactory.makeContainer(mode: mode) {
-                RootTabsView(mode: mode, container: container)
-                    .fpAppTheme()
-                    .modelContainer(container)
-            } else {
-                Text("Failed to initialise data store.")
+            Group {
+                // TODO(Epic 1 Story 1.6): Remove StoreMode, StoreFactory, -ui-tests-* launch args, and in-memory seeding
+                if mode == .inMemoryBlank || mode == .inMemorySeeded {
+                    if let container = StoreFactory.makeContainer(mode: mode) {
+                        RootTabsView(storeMode: mode)
+                            .fpAppTheme()
+                            .modelContainer(container)
+                    } else {
+                        Text("Failed to initialise data store.")
+                    }
+                } else {
+                    RootTabsView(storeMode: mode)
+                        .fpAppTheme()
+                }
             }
         }
+        .modelContainer(for: [Recipe.self, Menu.self])
     }
 }
 
-private struct RootTabsView: View {
-    
-    @State private var selectedTab: Int = 0 // 0 = Recipes, 1 = Menu
-    let mode: StoreMode
-    let container: ModelContainer
-
-    @State private var didSeed = false
-
-    var body: some View {
-        // Build repos & use cases from the provided container
-        let recipeRepo   = SwiftDataRecipeRepository(context: container.mainContext)
-        let menuRepo     = SwiftDataMenuRepository(context: container.mainContext)
-        let fetchUseCase = FetchRecipesUseCase(repository: recipeRepo)
-        let deleteUseCase = DeleteRecipeUseCase(repository: recipeRepo)
-        let generateUseCase = GenerateMenuUseCase(recipeRepository: recipeRepo, menuRepository: menuRepo)
-        let countUseCase = CountRecipesUseCase(repository: recipeRepo)
-
-        return TabView(selection: $selectedTab) {
-            RecipesView(
-                listVM: RecipesListViewModel(fetchUseCase: fetchUseCase, deleteUseCase: deleteUseCase),
-                makeAddVM: { recipe in
-                    AddRecipeViewModel(addRecipeUseCase: AddRecipeUseCase(repository: recipeRepo), updateRecipeUseCase: UpdateRecipesUseCase(repository: recipeRepo), existingRecipe: recipe) }
-            )
-            .tabItem { Label("Recipes", systemImage: "book") }
-            .tag(0)
-
-            GenerateMenuView(viewModel: GenerateMenuViewModel(generateUseCase: generateUseCase,
-                                                             countRecipesUseCase: countUseCase))
-                .tabItem { Label("Menu", systemImage: "calendar") }
-                .tag(1)
-        }
-        .task {
-            guard !didSeed else { return }
-            StoreFactory.seedIfNeeded(mode: mode, context: container.mainContext)
-            didSeed = true
-        }
-    }
-}
-
-// MARK: - Test/Prod Store Configuration Helper
-private enum StoreMode {
+// TODO(Epic 1 Story 1.6): Remove StoreMode, StoreFactory, -ui-tests-* launch args, and in-memory seeding
+enum StoreMode {
     case persistent
     case inMemoryBlank
     case inMemorySeeded
@@ -78,7 +48,8 @@ private enum StoreMode {
     }
 }
 
-private struct StoreFactory {
+// TODO(Epic 1 Story 1.6): Remove StoreMode, StoreFactory, -ui-tests-* launch args, and in-memory seeding
+struct StoreFactory {
     static func makeContainer(mode: StoreMode) -> ModelContainer? {
         switch mode {
         case .persistent:
@@ -92,15 +63,14 @@ private struct StoreFactory {
     static func seedIfNeeded(mode: StoreMode, context: ModelContext) {
         guard mode == .inMemorySeeded else { return }
 
-            // Seed at least 8 recipes to satisfy the menu rule
-            for i in 1...8 {
-                let r = Recipe(
-                    name: "Seeded \(i)",
-                    notes: i.isMultiple(of: 2) ? "Note \(i)" : nil
-                )
-                context.insert(r)
-            }
+        for i in 1...8 {
+            let r = Recipe(
+                name: "Seeded \(i)",
+                notes: i.isMultiple(of: 2) ? "Note \(i)" : nil
+            )
+            context.insert(r)
+        }
 
-            do { try context.save() } catch { /* ignore seed errors in tests */ }
+        do { try context.save() } catch { /* ignore seed errors in tests */ }
     }
 }

--- a/Sources/Views/RootTabsView.swift
+++ b/Sources/Views/RootTabsView.swift
@@ -1,0 +1,57 @@
+//
+//  RootTabsView.swift
+//  whattomake
+//
+//  Created by Amish Patel on 16/06/2026.
+//
+
+// Transitional: legacy use case wiring — delete with Epic 1 Story 1.4
+
+import SwiftUI
+import SwiftData
+
+struct RootTabsView: View {
+
+    @Environment(\.modelContext) private var modelContext
+    @State private var selectedTab = 0
+    let storeMode: StoreMode
+    @State private var didSeed = false
+
+    var body: some View {
+        let recipeRepo = SwiftDataRecipeRepository(context: modelContext)
+        let menuRepo = SwiftDataMenuRepository(context: modelContext)
+        let fetchUseCase = FetchRecipesUseCase(repository: recipeRepo)
+        let deleteUseCase = DeleteRecipeUseCase(repository: recipeRepo)
+        let generateUseCase = GenerateMenuUseCase(recipeRepository: recipeRepo, menuRepository: menuRepo)
+        let countUseCase = CountRecipesUseCase(repository: recipeRepo)
+
+        TabView(selection: $selectedTab) {
+            RecipesView(
+                listVM: RecipesListViewModel(fetchUseCase: fetchUseCase, deleteUseCase: deleteUseCase),
+                makeAddVM: { recipe in
+                    AddRecipeViewModel(
+                        addRecipeUseCase: AddRecipeUseCase(repository: recipeRepo),
+                        updateRecipeUseCase: UpdateRecipesUseCase(repository: recipeRepo),
+                        existingRecipe: recipe
+                    )
+                }
+            )
+            .tabItem { Label("Recipes", systemImage: "book") }
+            .tag(0)
+
+            GenerateMenuView(
+                viewModel: GenerateMenuViewModel(
+                    generateUseCase: generateUseCase,
+                    countRecipesUseCase: countUseCase
+                )
+            )
+            .tabItem { Label("Menu", systemImage: "calendar") }
+            .tag(1)
+        }
+        .task {
+            guard !didSeed else { return }
+            StoreFactory.seedIfNeeded(mode: storeMode, context: modelContext)
+            didSeed = true
+        }
+    }
+}

--- a/whattomake.xcodeproj/project.pbxproj
+++ b/whattomake.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		3B5E9E7E2AE07F9D00293473 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B5E9E7D2AE07F9D00293473 /* Assets.xcassets */; };
 		3B5E9E812AE07F9D00293473 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B5E9E802AE07F9D00293473 /* Preview Assets.xcassets */; };
 		3B64FDF62E56092F001E5915 /* UpdateRecipesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B64FDF52E560927001E5915 /* UpdateRecipesUseCase.swift */; };
+		3C1A00122E61D00100000001 /* RootTabsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1A00112E61D00100000001 /* RootTabsView.swift */; };
 		3BAD929C2E493AA6009DCBAE /* GenerateMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD929A2E4939DB009DCBAE /* GenerateMenuView.swift */; };
 		3BAD929D2E493AA6009DCBAE /* RecipesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD92992E4939D3009DCBAE /* RecipesListView.swift */; };
 		3BAD929E2E493AA6009DCBAE /* AddRecipeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD92982E4939C8009DCBAE /* AddRecipeView.swift */; };
@@ -109,6 +110,7 @@
 		3BAD92962E4939B5009DCBAE /* GenerateMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateMenuViewModel.swift; sourceTree = "<group>"; };
 		3BAD92982E4939C8009DCBAE /* AddRecipeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddRecipeView.swift; sourceTree = "<group>"; };
 		3BAD92992E4939D3009DCBAE /* RecipesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipesListView.swift; sourceTree = "<group>"; };
+		3C1A00112E61D00100000001 /* RootTabsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootTabsView.swift; sourceTree = "<group>"; };
 		3BAD929A2E4939DB009DCBAE /* GenerateMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateMenuView.swift; sourceTree = "<group>"; };
 		3BAD929B2E4939ED009DCBAE /* WeeklyMenuApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyMenuApp.swift; sourceTree = "<group>"; };
 		3BAD92AF2E494333009DCBAE /* DeleteRecipeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteRecipeUseCase.swift; sourceTree = "<group>"; };
@@ -349,6 +351,7 @@
 				3BAD929A2E4939DB009DCBAE /* GenerateMenuView.swift */,
 				3BAD92992E4939D3009DCBAE /* RecipesListView.swift */,
 				3BAD92982E4939C8009DCBAE /* AddRecipeView.swift */,
+				3C1A00112E61D00100000001 /* RootTabsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -513,6 +516,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C1A00122E61D00100000001 /* RootTabsView.swift in Sources */,
 				3BAD929C2E493AA6009DCBAE /* GenerateMenuView.swift in Sources */,
 				3BAFB0D02E538357001B185B /* Colors.swift in Sources */,
 				3B64FDF62E56092F001E5915 /* UpdateRecipesUseCase.swift in Sources */,


### PR DESCRIPTION
This PR thins `WeeklyMenuApp` to a proper SwiftUI composition root: persistent launches now use Scene-level `.modelContainer(for: [Recipe.self, Menu.self])`, and all use case, repository, and ViewModel wiring is removed from the `@main` entry point. Legacy dependency construction is relocated unchanged to a new transitional `RootTabsView`, which obtains `modelContext` from the environment and preserves the existing Recipes and Menu tab behavior until Epic 1 Stories 1.2–1.4 migrate views to `@Query`.

UITest in-memory store modes (`-ui-tests-blank`, `-ui-tests-seeded`) are preserved with content-level container overrides and Story 1.6 TODO markers; `StoreMode` and `StoreFactory` remain in `WeeklyMenuApp.swift` with internal visibility for cross-file access. Scope is limited to three files — no changes to legacy layers, tests, or view implementations. Build and all 25 unit tests pass on the pinned iPhone 17 Pro simulator.