### PR TITLE
fix(ci): default to build 1 when no TestFlight builds exist

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -76,10 +76,16 @@ platform :ios do
         keychain_name: keychain_name
       )
 
-      build_number = latest_testflight_build_number(
-        app_identifier: APP_IDENTIFIER,
-        version: marketing_version
-      ) + 1
+      begin
+        latest_build = latest_testflight_build_number(
+          app_identifier: APP_IDENTIFIER,
+          version: marketing_version
+        )
+        build_number = latest_build + 1
+      rescue => e
+        UI.important("No TestFlight builds found for #{marketing_version}: #{e.message}")
+        build_number = 1
+      end
 
       increment_build_number(
         build_number: build_number,


### PR DESCRIPTION
latest_testflight_build_number fails for new marketing versions (1.1.0) with no prior TestFlight uploads, causing the Deploy step to exit before gym runs. Restore the rescue fallback removed in #25.