### PR TITLE
refactor(menu): migrate GenerateMenuView to @Query and helpers

### DIFF
--- a/Sources/Application/WeeklyMenuApp.swift
+++ b/Sources/Application/WeeklyMenuApp.swift
@@ -11,6 +11,10 @@ import SwiftData
 
 @main
 struct WeeklyMenuApp: App {
+    init() {
+        DaySelectionStorage.registerDefaults()
+    }
+
     var body: some Scene {
         let mode = StoreMode.current()
         WindowGroup {

--- a/Sources/Helpers/AppStorageKey.swift
+++ b/Sources/Helpers/AppStorageKey.swift
@@ -1,0 +1,13 @@
+//
+//  AppStorageKey.swift
+//  whattomake
+//
+//  Created by Amish Patel on 16/06/2026.
+//
+
+import Foundation
+
+/// Canonical `@AppStorage` keys — do not scatter raw strings elsewhere.
+enum AppStorageKey: String {
+    case selectedDays
+}

--- a/Sources/Helpers/DaySelectionStorage.swift
+++ b/Sources/Helpers/DaySelectionStorage.swift
@@ -1,0 +1,58 @@
+//
+//  DaySelectionStorage.swift
+//  whattomake
+//
+//  Created by Amish Patel on 16/06/2026.
+//
+
+import Foundation
+import SwiftUI
+
+/// Encodes and decodes weekday selection persisted via `@AppStorage`.
+enum DaySelectionStorage {
+    static let defaultValue = ""
+    private static let canonicalDays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+    /// Registers empty day selection default in `UserDefaults`.
+    static func registerDefaults() {
+        UserDefaults.standard.register(defaults: [
+            AppStorageKey.selectedDays.rawValue: defaultValue
+        ])
+    }
+
+    /// Decodes comma-separated day identifiers into a validated set.
+    static func decode(_ raw: String) -> Set<String> {
+        let allowed = Set(canonicalDays)
+        return Set(
+            raw.split(separator: ",")
+                .map { String($0) }
+                .filter { !$0.isEmpty && allowed.contains($0) }
+        )
+    }
+
+    /// Encodes selected days in canonical Mon→Sun order for stable persistence.
+    static func encode(_ days: Set<String>) -> String {
+        canonicalDays.filter { days.contains($0) }.joined(separator: ",")
+    }
+
+    /// Returns canonical weekday order for menu generation.
+    static func orderedDays(from days: Set<String>) -> [String] {
+        canonicalDays.filter { days.contains($0) }
+    }
+
+    /// Toggle binding backed by comma-separated `@AppStorage` raw value.
+    static func toggleBinding(for day: String, raw: Binding<String>) -> Binding<Bool> {
+        Binding(
+            get: { decode(raw.wrappedValue).contains(day) },
+            set: { isOn in
+                var days = decode(raw.wrappedValue)
+                if isOn {
+                    days.insert(day)
+                } else {
+                    days.remove(day)
+                }
+                raw.wrappedValue = encode(days)
+            }
+        )
+    }
+}

--- a/Sources/Helpers/MenuGenerator.swift
+++ b/Sources/Helpers/MenuGenerator.swift
@@ -1,0 +1,22 @@
+//
+//  MenuGenerator.swift
+//  whattomake
+//
+//  Created by Amish Patel on 16/06/2026.
+//
+
+import Foundation
+
+/// Pure menu selection logic — shuffle + prefix, mirroring legacy use case semantics.
+struct MenuGenerator {
+    /// Selects one recipe per requested day via shuffle and prefix.
+    /// - Parameters:
+    ///   - recipes: Available recipes to choose from.
+    ///   - days: Ordered day identifiers; count determines selection size.
+    /// - Returns: Selected recipes in day order (may be fewer than `days.count` if insufficient recipes).
+    static func select(from recipes: [Recipe], forDays days: [String]) -> [Recipe] {
+        var shuffled = recipes
+        shuffled.shuffle()
+        return Array(shuffled.prefix(days.count))
+    }
+}

--- a/Sources/Helpers/MenuPersistence.swift
+++ b/Sources/Helpers/MenuPersistence.swift
@@ -1,0 +1,26 @@
+//
+//  MenuPersistence.swift
+//  whattomake
+//
+//  Created by Amish Patel on 16/06/2026.
+//
+
+import Foundation
+import SwiftData
+
+/// Menu write helpers — delete-before-insert lifecycle for regenerate.
+enum MenuPersistence {
+    /// Deletes all existing menus, inserts the new snapshot, and saves.
+    /// - Parameters:
+    ///   - menu: The menu snapshot to persist.
+    ///   - context: SwiftData model context for writes.
+    /// - Throws: Fetch, delete, or save errors from SwiftData.
+    static func replaceMenu(with menu: Menu, in context: ModelContext) throws {
+        let existing = try context.fetch(FetchDescriptor<Menu>())
+        for existingMenu in existing {
+            context.delete(existingMenu)
+        }
+        context.insert(menu)
+        try context.save()
+    }
+}

--- a/Sources/Models/Menu.swift
+++ b/Sources/Models/Menu.swift
@@ -50,3 +50,10 @@ final class Menu {
         self.recipes = recipes
     }
 }
+
+extension Menu {
+    /// Fetch descriptor for the latest generated menu (`generatedDate` descending).
+    static func latestDescriptor() -> FetchDescriptor<Menu> {
+        FetchDescriptor(sortBy: [SortDescriptor(\Menu.generatedDate, order: .reverse)])
+    }
+}

--- a/Sources/Views/GenerateMenuView.swift
+++ b/Sources/Views/GenerateMenuView.swift
@@ -5,11 +5,35 @@
 //  Created by Amish Patel on 10/08/2025.
 //
 import SwiftUI
+import SwiftData
 import Observation
 
+@MainActor
+@Observable
+final class GenerateMenuCoordinator {
+    var errorMessage: String?
+    var isGenerating = false
+}
+
 struct GenerateMenuView: View {
-    @Bindable var viewModel: GenerateMenuViewModel
-    private let weekDays = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"]
+    @Query(sort: \Recipe.name) private var recipes: [Recipe]
+    @Query private var menus: [Menu]
+    @Environment(\.modelContext) private var modelContext
+    @State private var coordinator = GenerateMenuCoordinator()
+    @AppStorage(AppStorageKey.selectedDays.rawValue) private var selectedDaysRaw = DaySelectionStorage.defaultValue
+
+    private let weekDays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    private let minRecipesRequired = 7
+
+    private var latestMenu: Menu? { menus.first }
+    private var selectedDays: Set<String> { DaySelectionStorage.decode(selectedDaysRaw) }
+    private var canGenerate: Bool {
+        !selectedDays.isEmpty && recipes.count >= minRecipesRequired && !coordinator.isGenerating
+    }
+
+    init() {
+        _menus = Query(Menu.latestDescriptor())
+    }
 
     var body: some View {
         NavigationStack {
@@ -17,24 +41,21 @@ struct GenerateMenuView: View {
                 // MARK: Day selection
                 Section("Select days") {
                     ForEach(weekDays, id: \.self) { day in
-                        Toggle(day, isOn: Binding(
-                            get: { viewModel.selectedDays.contains(day) },
-                            set: { isOn in
-                                if isOn { viewModel.selectedDays.append(day) }
-                                else { viewModel.selectedDays.removeAll { $0 == day } }
-                            }
-                        ))
-                        .fpTinted() // DS accent tint
+                        Toggle(
+                            day,
+                            isOn: DaySelectionStorage.toggleBinding(for: day, raw: $selectedDaysRaw)
+                        )
+                        .fpTinted()
                         .accessibilityIdentifier("toggleDay_\(day)")
                     }
                 }
 
                 // MARK: Requirement / status
                 Section {
-                    Text("Need at least \(viewModel.minRecipesRequired) recipes to generate. You have \(viewModel.availableRecipeCount).")
+                    Text("Need at least \(minRecipesRequired) recipes to generate. You have \(recipes.count).")
                         .font(FpTypography.caption)
                         .foregroundStyle(
-                            viewModel.availableRecipeCount >= viewModel.minRecipesRequired
+                            recipes.count >= minRecipesRequired
                             ? Color.fpSecondaryLabel
                             : .red
                         )
@@ -43,17 +64,25 @@ struct GenerateMenuView: View {
 
                 // MARK: Generate button (grouped inside form)
                 Section {
-                    Button("Generate Menu") {
-                        viewModel.generate()
+                    Button {
+                        generateMenu()
+                    } label: {
+                        HStack {
+                            if coordinator.isGenerating {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
+                            Text(coordinator.isGenerating ? "Generating…" : "Generate Menu")
+                        }
                     }
                     .fpPrimary()
-                    .disabled(!viewModel.canGenerate)
+                    .disabled(!canGenerate)
+                    .opacity(coordinator.isGenerating ? 0.7 : 1)
                     .accessibilityIdentifier("generateMenuButton")
-                    // Note: disabled state will appear system-grey inside Form; acceptable per HIG
                 }
 
                 // MARK: Validation message (if any)
-                if let message = viewModel.errorMessage {
+                if let message = coordinator.errorMessage {
                     Section {
                         Text(message)
                             .font(FpTypography.body)
@@ -62,8 +91,17 @@ struct GenerateMenuView: View {
                     }
                 }
 
+                // MARK: Empty state
+                if latestMenu == nil {
+                    Section {
+                        Text(MenuEmptyStateCopy.message)
+                            .font(FpTypography.body)
+                            .foregroundStyle(Color.fpSecondaryLabel)
+                    }
+                }
+
                 // MARK: Generated menu (value snapshot for stability)
-                if let menu = viewModel.generatedMenu {
+                if let menu = latestMenu {
                     let rows: [(day: String, name: String)] = {
                         let names = menu.recipes.map { $0.name }
                         return Array(zip(menu.days, names))
@@ -80,15 +118,49 @@ struct GenerateMenuView: View {
                             .accessibilityIdentifier("menuItem_\(row.day)")
                         }
                     }
-                    .id(menu.id) // keep subtree stable when regenerating
+                    .id(menu.id)
                 }
             }
             .listStyle(.insetGrouped)
             .navigationTitle("Generate Menu")
             .toolbarTitleDisplayMode(.inline)
         }
-        .task {
-            await viewModel.loadAvailability()
+    }
+
+    private func generateMenu() {
+        guard !coordinator.isGenerating else { return }
+
+        guard recipes.count >= minRecipesRequired else {
+            coordinator.errorMessage = "You need at least \(minRecipesRequired) recipes to generate a menu. You currently have \(recipes.count)."
+            return
+        }
+
+        guard !selectedDays.isEmpty else {
+            coordinator.errorMessage = "Please select at least one day."
+            return
+        }
+
+        coordinator.errorMessage = nil
+        coordinator.isGenerating = true
+
+        Task { @MainActor in
+            defer { coordinator.isGenerating = false }
+            await Task.yield()
+
+            let orderedDays = DaySelectionStorage.orderedDays(from: selectedDays)
+            let selectedRecipes = MenuGenerator.select(from: recipes, forDays: orderedDays)
+            let menu = Menu(days: orderedDays, recipes: selectedRecipes)
+
+            do {
+                try MenuPersistence.replaceMenu(with: menu, in: modelContext)
+                for recipe in selectedRecipes {
+                    recipe.usageCount += 1
+                }
+                try modelContext.save()
+                coordinator.errorMessage = nil
+            } catch {
+                coordinator.errorMessage = error.localizedDescription
+            }
         }
     }
 }

--- a/Sources/Views/RootTabsView.swift
+++ b/Sources/Views/RootTabsView.swift
@@ -19,11 +19,8 @@ struct RootTabsView: View {
 
     var body: some View {
         let recipeRepo = SwiftDataRecipeRepository(context: modelContext)
-        let menuRepo = SwiftDataMenuRepository(context: modelContext)
         let fetchUseCase = FetchRecipesUseCase(repository: recipeRepo)
         let deleteUseCase = DeleteRecipeUseCase(repository: recipeRepo)
-        let generateUseCase = GenerateMenuUseCase(recipeRepository: recipeRepo, menuRepository: menuRepo)
-        let countUseCase = CountRecipesUseCase(repository: recipeRepo)
 
         TabView(selection: $selectedTab) {
             RecipesView(
@@ -39,12 +36,7 @@ struct RootTabsView: View {
             .tabItem { Label("Recipes", systemImage: "book") }
             .tag(0)
 
-            GenerateMenuView(
-                viewModel: GenerateMenuViewModel(
-                    generateUseCase: generateUseCase,
-                    countRecipesUseCase: countUseCase
-                )
-            )
+            GenerateMenuView()
             .tabItem { Label("Menu", systemImage: "calendar") }
             .tag(1)
         }

--- a/whattomake.xcodeproj/project.pbxproj
+++ b/whattomake.xcodeproj/project.pbxproj
@@ -61,6 +61,10 @@
 		3C0A00112E60B00300000002 /* TestModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00102E60B00300000001 /* TestModelContainer.swift */; };
 		3C0A00132E60B00300000004 /* TestModelContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00122E60B00300000003 /* TestModelContainerTests.swift */; };
 		3C0A00162E60C00400000002 /* MenuEmptyStateCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00152E60C00400000001 /* MenuEmptyStateCopy.swift */; };
+		3C0A001C2E60D00500000005 /* AppStorageKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00182E60D00500000001 /* AppStorageKey.swift */; };
+		3C0A001D2E60D00500000006 /* DaySelectionStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00192E60D00500000002 /* DaySelectionStorage.swift */; };
+		3C0A001E2E60D00500000007 /* MenuGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A001A2E60D00500000003 /* MenuGenerator.swift */; };
+		3C0A001F2E60D00500000008 /* MenuPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A001B2E60D00500000004 /* MenuPersistence.swift */; };
 		3C0A00052E60A00100000005 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 3C0A00042E60A00100000004 /* SnapshotTesting */; };
 /* End PBXBuildFile section */
 
@@ -142,6 +146,10 @@
 		3C0A00102E60B00300000001 /* TestModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModelContainer.swift; sourceTree = "<group>"; };
 		3C0A00122E60B00300000003 /* TestModelContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModelContainerTests.swift; sourceTree = "<group>"; };
 		3C0A00152E60C00400000001 /* MenuEmptyStateCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuEmptyStateCopy.swift; sourceTree = "<group>"; };
+		3C0A00182E60D00500000001 /* AppStorageKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorageKey.swift; sourceTree = "<group>"; };
+		3C0A00192E60D00500000002 /* DaySelectionStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaySelectionStorage.swift; sourceTree = "<group>"; };
+		3C0A001A2E60D00500000003 /* MenuGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuGenerator.swift; sourceTree = "<group>"; };
+		3C0A001B2E60D00500000004 /* MenuPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuPersistence.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -306,6 +314,10 @@
 		3C0A00172E60C00400000003 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				3C0A00182E60D00500000001 /* AppStorageKey.swift */,
+				3C0A00192E60D00500000002 /* DaySelectionStorage.swift */,
+				3C0A001A2E60D00500000003 /* MenuGenerator.swift */,
+				3C0A001B2E60D00500000004 /* MenuPersistence.swift */,
 				3C0A00152E60C00400000001 /* MenuEmptyStateCopy.swift */,
 			);
 			path = Helpers;
@@ -544,6 +556,10 @@
 				3BAD92AB2E493AA6009DCBAE /* RecipeRepository.swift in Sources */,
 				3BAD92AC2E493AA6009DCBAE /* Menu.swift in Sources */,
 				3C0A00162E60C00400000002 /* MenuEmptyStateCopy.swift in Sources */,
+				3C0A001C2E60D00500000005 /* AppStorageKey.swift in Sources */,
+				3C0A001D2E60D00500000006 /* DaySelectionStorage.swift in Sources */,
+				3C0A001E2E60D00500000007 /* MenuGenerator.swift in Sources */,
+				3C0A001F2E60D00500000008 /* MenuPersistence.swift in Sources */,
 				3BAD92AD2E493AA6009DCBAE /* Recipe.swift in Sources */,
 				3BAFB0C52E537D72001B185B /* Layout.swift in Sources */,
 				3BAD92AE2E493AA6009DCBAE /* WeeklyMenuApp.swift in Sources */,


### PR DESCRIPTION
Migrates the Generate Menu screen off Clean Architecture (ViewModel + use cases) to SwiftUI-native data flow. `GenerateMenuView` now reads recipes and the latest menu via `@Query`, persists day toggles through `@AppStorage` and `DaySelectionStorage`, and writes menus with delete-before-insert via `MenuPersistence`. New pure helpers — `MenuGenerator`, `MenuPersistence`, `DaySelectionStorage`, and `AppStorageKey` — replace the generate/count use case wiring removed from `RootTabsView`. This fixes FR6 structurally: generated menus survive app relaunch without manual load wiring.

Includes empty-state coaching copy, preserved accessibility identifiers and DesignSystem styling, and code review hardening: async `Task`-based loading feedback (UX-DR5), `usageCount` increments only after a successful menu save, and a re-entrancy guard against double-tap generate. Legacy use cases, repositories, and ViewModels remain in the repo for Story 1.4 deletion; only the Menu tab stops depending on them.