### PR TITLE
fix(ci): read marketing version from app target build settings

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,6 +17,7 @@ default_platform(:ios)
 platform :ios do
   PROJECT_NAME = "whattomake.xcodeproj"
   APP_IDENTIFIER = "amishpatel.whattomake"
+  APP_TARGET = "whattomake"
   PROVISIONING_PROFILE_NAME = "ForkPlan App Store"
   PINNED_TEST_DESTINATION = "platform=iOS Simulator,name=iPhone 17 Pro"
 
@@ -47,7 +48,7 @@ platform :ios do
 
     marketing_version = get_version_number(
       xcodeproj: PROJECT_NAME,
-      configuration: "Release"
+      target: APP_TARGET
     )
 
     UI.message("GitHub release version: #{release_version}")


### PR DESCRIPTION
get_version_number with configuration: Release crashes on fastlane 2.236 when the app uses GENERATE_INFOPLIST_FILE (no INFOPLIST_FILE path). Pass the whattomake target instead so MARKETING_VERSION resolves from build settings.