### PR TITLE
refactor(recipes): migrate RecipesView and AddRecipeView to @Query

### DIFF
--- a/Sources/Views/AddRecipeView.swift
+++ b/Sources/Views/AddRecipeView.swift
@@ -6,17 +6,117 @@
 import SwiftUI
 import Observation
 import PhotosUI
+import SwiftData
+import UIKit
+
+@MainActor
+@Observable
+final class AddRecipeCoordinator {
+    var name = ""
+    var notes = ""
+    var selectedPhotoItem: PhotosPickerItem?
+    var previewImage: UIImage?
+    var thumbnailBase64: String?
+    var imageFilename: String?
+    var errorMessage: String?
+    var isSaving = false
+    private var pendingRecipe: Recipe?
+
+    func load(from recipe: Recipe) {
+        name = recipe.name
+        notes = recipe.notes ?? ""
+        thumbnailBase64 = recipe.thumbnailBase64
+        imageFilename = recipe.imageFilename
+        if let thumbnailBase64 = recipe.thumbnailBase64 {
+            previewImage = ImageCodec.image(fromBase64: thumbnailBase64)
+        }
+    }
+
+    func loadSelectedImage() {
+        guard let item = selectedPhotoItem else { return }
+        Task { @MainActor in
+            do {
+                if let data = try await item.loadTransferable(type: Data.self) {
+                    await handleLoadedImageData(data)
+                } else {
+                    errorMessage = "Could not load photo."
+                }
+            } catch {
+                errorMessage = "Failed to load photo."
+            }
+        }
+    }
+
+    func handleLoadedImageData(_ data: Data) async {
+        if let uiImage = UIImage(data: data) {
+            let thumbnail = ImageCodec.base64JPEGThumbnail(from: uiImage)
+            let filename = try? ImageStore.saveOriginal(uiImage)
+            previewImage = uiImage
+            thumbnailBase64 = thumbnail
+            imageFilename = filename
+            errorMessage = nil
+        } else {
+            errorMessage = "Could not load photo."
+        }
+    }
+
+    func save(existingRecipe: Recipe?, in context: ModelContext) async -> Bool {
+        guard !isSaving else { return false }
+        isSaving = true
+        defer { isSaving = false }
+
+        if existingRecipe == nil {
+            guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+                errorMessage = RecipeError.emptyName.localizedDescription
+                return false
+            }
+        }
+
+        do {
+            if let existingRecipe {
+                existingRecipe.name = name
+                existingRecipe.notes = notes
+                existingRecipe.thumbnailBase64 = thumbnailBase64
+                existingRecipe.imageFilename = imageFilename
+            } else if let pendingRecipe {
+                pendingRecipe.name = name.trimmingCharacters(in: .whitespaces)
+                pendingRecipe.notes = notes.isEmpty ? nil : notes
+                pendingRecipe.thumbnailBase64 = thumbnailBase64
+                pendingRecipe.imageFilename = imageFilename
+            } else {
+                let recipe = Recipe(
+                    name: name.trimmingCharacters(in: .whitespaces),
+                    notes: notes.isEmpty ? nil : notes,
+                    thumbnailBase64: thumbnailBase64,
+                    imageFilename: imageFilename
+                )
+                context.insert(recipe)
+                pendingRecipe = recipe
+            }
+            try context.save()
+            pendingRecipe = nil
+            errorMessage = nil
+            return true
+        } catch {
+            errorMessage = error.localizedDescription
+            return false
+        }
+    }
+}
 
 struct AddRecipeView: View {
-    @Bindable var viewModel: AddRecipeViewModel
+    let existingRecipe: Recipe?
+    @Bindable var coordinator: AddRecipeCoordinator
     @FocusState private var focusedField: Field?
     enum Field { case name, notes }
-    
+
+    private var isEditing: Bool { existingRecipe != nil }
+
     var body: some View {
         List {
             // MARK: Photo
             Section("Photo") {
-                if let ui = viewModel.previewImage {
+                if let ui = coordinator.previewImage {
                     Image(uiImage: ui)
                         .resizable()
                         .scaledToFit()
@@ -24,23 +124,22 @@ struct AddRecipeView: View {
                         .padding(1) // stay inside stroke
                         .accessibilityIdentifier("recipeImagePreview")
                 }
-                
-                
-                PhotosPicker(selection: $viewModel.selectedPhotoItem, matching: .images) {
+
+                PhotosPicker(selection: $coordinator.selectedPhotoItem, matching: .images) {
                     Label("Choose Photo", systemImage: "photo.on.rectangle")
                         .font(FpTypography.body)
                 }
                 .tint(Color.fpAccent)
-                .onChange(of: viewModel.selectedPhotoItem, initial: false) {
-                    viewModel.loadSelectedImage()
+                .onChange(of: coordinator.selectedPhotoItem, initial: false) {
+                    coordinator.loadSelectedImage()
                 }
                 .accessibilityIdentifier("choosePhotoButton")
             }
             .listRowSeparator(.hidden)
-            
+
             // MARK: Recipe
             Section("Recipe") {
-                TextField("Recipe Name", text: $viewModel.name)
+                TextField("Recipe Name", text: $coordinator.name)
                     .font(FpTypography.body)
                     .foregroundStyle(Color.fpLabel)
                     .textInputAutocapitalization(.words)
@@ -49,9 +148,8 @@ struct AddRecipeView: View {
                     .focused($focusedField, equals: .name)
                     .onSubmit { focusedField = .notes }
                     .accessibilityIdentifier("recipeNameField")
-                
-                // Multiline notes feels better for real usage
-                TextField("Notes", text: $viewModel.notes, axis: .vertical)
+
+                TextField("Notes", text: $coordinator.notes, axis: .vertical)
                     .lineLimit(1...3)
                     .font(FpTypography.body)
                     .foregroundStyle(Color.fpLabel)
@@ -61,9 +159,9 @@ struct AddRecipeView: View {
                     .focused($focusedField, equals: .notes)
                     .accessibilityIdentifier("notesField")
             }
-            
+
             // MARK: Error
-            if let error = viewModel.errorMessage {
+            if let error = coordinator.errorMessage {
                 Section {
                     Text(error)
                         .font(FpTypography.body)
@@ -73,7 +171,7 @@ struct AddRecipeView: View {
             }
         }
         .listStyle(.insetGrouped)
-        .navigationTitle(viewModel.isEditing ? "Edit Recipe" : "Add Recipe")
+        .navigationTitle(isEditing ? "Edit Recipe" : "Add Recipe")
         .scrollDismissesKeyboard(.interactively)
     }
 }

--- a/Sources/Views/RecipesListView.swift
+++ b/Sources/Views/RecipesListView.swift
@@ -5,19 +5,19 @@
 //  Created by Amish Patel on 10/08/2025.
 //
 import SwiftUI
-import Observation
+import SwiftData
 
 struct RecipesView: View {
-    @Bindable var listVM: RecipesListViewModel
+    @Query(sort: \Recipe.name) private var recipes: [Recipe]
+    @Environment(\.modelContext) private var modelContext
     @State private var showAdd = false
-    let makeAddVM: (Recipe?) -> AddRecipeViewModel
-    @State var selectedRecipe: Recipe? = nil
-    
+    @State private var selectedRecipe: Recipe?
+    @State private var deleteErrorMessage: String?
+
     var body: some View {
         NavigationStack {
             Group {
-                if listVM.recipes.isEmpty {
-                    // Empty state
+                if recipes.isEmpty {
                     VStack(spacing: 16) {
                         ContentUnavailableView(
                             "No Recipes",
@@ -27,21 +27,19 @@ struct RecipesView: View {
                     }
                     .padding(.horizontal, FpLayout.screenPadding)
                     .accessibilityIdentifier("emptyRecipesView")
-                    
+
                 } else {
-                    // List of recipes
                     List {
-                        ForEach(listVM.recipes, id: \.id) { recipe in
+                        ForEach(recipes, id: \.id) { recipe in
                             HStack(spacing: 12) {
-                                // Thumbnail OR placeholder
                                 RecipeThumbView(base64: recipe.thumbnailBase64)
-                                
+
                                 VStack(alignment: .leading, spacing: 4) {
                                     Text(recipe.name)
                                         .font(FpTypography.body)
                                         .foregroundStyle(Color.fpLabel)
                                         .accessibilityIdentifier("recipeName_\(recipe.name)")
-                                    
+
                                     if let notes = recipe.notes, !notes.isEmpty {
                                         Text(notes)
                                             .font(FpTypography.caption)
@@ -55,15 +53,15 @@ struct RecipesView: View {
                                 selectedRecipe = recipe
                             }
                         }
-                        .onDelete(perform: listVM.delete)
+                        .onDelete(perform: deleteRecipes)
                     }
                     .accessibilityIdentifier("recipesList")
                     .listStyle(.plain)
-                    .scrollContentBackground(.hidden)          // show fpBackground behind the list
+                    .scrollContentBackground(.hidden)
                 }
             }
             .navigationTitle("Recipes")
-            .tint(Color.fpAccent)                             // local tint (remove if you apply fpAppTheme at root)
+            .tint(Color.fpAccent)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
@@ -74,48 +72,83 @@ struct RecipesView: View {
                     .accessibilityIdentifier("addRecipeButton")
                 }
             }
-            .onAppear { listVM.load() }
-            .sheet(isPresented: $showAdd, onDismiss: { listVM.load() }) {
-                let addVM = makeAddVM(nil)
-                NavigationStack {
-                    AddRecipeView(viewModel: addVM)
-                        .toolbar {
-                            ToolbarItem(placement: .cancellationAction) {
-                                Button("Cancel") { showAdd = false }
-                                    .accessibilityIdentifier("cancelAddRecipeButton")
-                            }
-                            ToolbarItem(placement: .confirmationAction) {
-                                Button("Save") {
-                                    Task {
-                                        if await addVM.saveRecipe() { showAdd = false }
-                                    }
-                                }
-                                .accessibilityIdentifier("saveRecipeButton")
-                            }
-                        }
-                }
+            .sheet(isPresented: $showAdd) {
+                AddRecipeSheetContent(existingRecipe: nil, onDismiss: { showAdd = false })
             }
-            .sheet(item: $selectedRecipe, onDismiss: { listVM.load() }) { recipe in
-                let editVM = makeAddVM(recipe)
-                NavigationStack {
-                    AddRecipeView(viewModel: editVM)
-                        .toolbar {
-                            ToolbarItem(placement: .cancellationAction) {
-                                Button("Cancel") { selectedRecipe = nil }
-                                    .accessibilityIdentifier("cancelAddRecipeButton")
-                            }
-                            ToolbarItem(placement: .confirmationAction) {
-                                Button("Save") {
-                                    Task {
-                                        if await editVM.saveRecipe() { selectedRecipe = nil }
-                                    }
-                                }
-                                .accessibilityIdentifier("saveRecipeButton")
-                            }
-                        }
+            .sheet(item: $selectedRecipe) { recipe in
+                AddRecipeSheetContent(existingRecipe: recipe, onDismiss: { selectedRecipe = nil })
+            }
+            .alert("Could Not Delete Recipe", isPresented: deleteErrorPresented) {
+                Button("OK", role: .cancel) { deleteErrorMessage = nil }
+            } message: {
+                if let deleteErrorMessage {
+                    Text(deleteErrorMessage)
                 }
             }
             .background(Color.fpBackground)
+        }
+    }
+
+    private var deleteErrorPresented: Binding<Bool> {
+        Binding(
+            get: { deleteErrorMessage != nil },
+            set: { if !$0 { deleteErrorMessage = nil } }
+        )
+    }
+
+    private func deleteRecipes(at offsets: IndexSet) {
+        for index in offsets {
+            let recipe = recipes[index]
+            if let filename = recipe.imageFilename {
+                ImageStore.delete(named: filename)
+            }
+            modelContext.delete(recipe)
+        }
+        do {
+            try modelContext.save()
+            deleteErrorMessage = nil
+        } catch {
+            deleteErrorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct AddRecipeSheetContent: View {
+    let existingRecipe: Recipe?
+    let onDismiss: () -> Void
+    @State private var coordinator: AddRecipeCoordinator
+    @Environment(\.modelContext) private var modelContext
+
+    init(existingRecipe: Recipe?, onDismiss: @escaping () -> Void) {
+        self.existingRecipe = existingRecipe
+        self.onDismiss = onDismiss
+        let coordinator = AddRecipeCoordinator()
+        if let existingRecipe {
+            coordinator.load(from: existingRecipe)
+        }
+        _coordinator = State(initialValue: coordinator)
+    }
+
+    var body: some View {
+        NavigationStack {
+            AddRecipeView(existingRecipe: existingRecipe, coordinator: coordinator)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel", action: onDismiss)
+                            .accessibilityIdentifier("cancelAddRecipeButton")
+                    }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Save") {
+                            Task { @MainActor in
+                                if await coordinator.save(existingRecipe: existingRecipe, in: modelContext) {
+                                    onDismiss()
+                                }
+                            }
+                        }
+                        .disabled(coordinator.isSaving)
+                        .accessibilityIdentifier("saveRecipeButton")
+                    }
+                }
         }
     }
 }
@@ -125,10 +158,9 @@ struct RecipesView: View {
 /// - fpSurface background + subtle stroke for dark mode
 private struct RecipeThumbView: View {
     let base64: String?
-    
+
     var body: some View {
         ZStack {
-            // Surface background for both thumb and placeholder
             RoundedRectangle(cornerRadius: 8)
                 .fill(Color.fpSurface)
                 .frame(width: 44, height: 44)
@@ -136,7 +168,7 @@ private struct RecipeThumbView: View {
                     RoundedRectangle(cornerRadius: 8)
                         .stroke(Color.fpSeparator.opacity(0.25), lineWidth: 0.5)
                 )
-            
+
             if let base64, let ui = ImageCodec.image(fromBase64: base64) {
                 Image(uiImage: ui)
                     .resizable()
@@ -155,36 +187,17 @@ private struct RecipeThumbView: View {
 }
 
 #if DEBUG
-@MainActor
-private final class PreviewMockRecipeRepository: RecipeRepository {
-    private var storage: [Recipe]
-    init(initial: [Recipe] = []) { self.storage = initial }
-    func add(_ recipe: Recipe) async throws { storage.append(recipe) }
-    func update(_ recipe: Recipe) async throws {
-        if let idx = storage.firstIndex(where: { $0.id == recipe.id }) { storage[idx] = recipe }
-    }
-    func delete(_ recipe: Recipe) async throws { storage.removeAll { $0.id == recipe.id } }
-    func fetchAll() async throws -> [Recipe] { storage }
-}
-
 #Preview("Empty") {
-    let repo = PreviewMockRecipeRepository(initial: [])
-    let fetch = FetchRecipesUseCase(repository: repo)
-    let delete = DeleteRecipeUseCase(repository: repo)
-    let vm = RecipesListViewModel(fetchUseCase: fetch, deleteUseCase: delete)
-    RecipesView(listVM: vm, makeAddVM: { _ in
-        AddRecipeViewModel(addRecipeUseCase: AddRecipeUseCase(repository: repo), updateRecipeUseCase: UpdateRecipesUseCase(repository: repo))
-    })
+    RecipesView()
+        .modelContainer(for: Recipe.self, inMemory: true)
 }
 
 #Preview("With Recipes") {
-    let repo = PreviewMockRecipeRepository(initial: [
-        Recipe(name: "Pasta", notes: "Family favorite"),
-        Recipe(name: "Tacos", notes: "Tuesday special")
-    ])
-    let fetch = FetchRecipesUseCase(repository: repo)
-    let delete = DeleteRecipeUseCase(repository: repo)
-    let vm = RecipesListViewModel(fetchUseCase: fetch, deleteUseCase: delete)
-    
+    let container = try! ModelContainer(for: Recipe.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+    let context = container.mainContext
+    context.insert(Recipe(name: "Pasta", notes: "Family favorite"))
+    context.insert(Recipe(name: "Tacos", notes: "Tuesday special"))
+    return RecipesView()
+        .modelContainer(container)
 }
 #endif

--- a/Sources/Views/RootTabsView.swift
+++ b/Sources/Views/RootTabsView.swift
@@ -5,7 +5,7 @@
 //  Created by Amish Patel on 16/06/2026.
 //
 
-// Transitional: legacy use case wiring — delete with Epic 1 Story 1.4
+// Transitional: StoreFactory.seedIfNeeded — delete with Epic 1 Story 1.6
 
 import SwiftUI
 import SwiftData
@@ -18,27 +18,14 @@ struct RootTabsView: View {
     @State private var didSeed = false
 
     var body: some View {
-        let recipeRepo = SwiftDataRecipeRepository(context: modelContext)
-        let fetchUseCase = FetchRecipesUseCase(repository: recipeRepo)
-        let deleteUseCase = DeleteRecipeUseCase(repository: recipeRepo)
-
         TabView(selection: $selectedTab) {
-            RecipesView(
-                listVM: RecipesListViewModel(fetchUseCase: fetchUseCase, deleteUseCase: deleteUseCase),
-                makeAddVM: { recipe in
-                    AddRecipeViewModel(
-                        addRecipeUseCase: AddRecipeUseCase(repository: recipeRepo),
-                        updateRecipeUseCase: UpdateRecipesUseCase(repository: recipeRepo),
-                        existingRecipe: recipe
-                    )
-                }
-            )
-            .tabItem { Label("Recipes", systemImage: "book") }
-            .tag(0)
+            RecipesView()
+                .tabItem { Label("Recipes", systemImage: "book") }
+                .tag(0)
 
             GenerateMenuView()
-            .tabItem { Label("Menu", systemImage: "calendar") }
-            .tag(1)
+                .tabItem { Label("Menu", systemImage: "calendar") }
+                .tag(1)
         }
         .task {
             guard !didSeed else { return }


### PR DESCRIPTION
## Summary
- Migrates the Recipes tab off Clean Architecture ViewModels/use cases to SwiftUI-native `@Query` reads and `modelContext` writes (Story 1.3).
- Introduces `AddRecipeCoordinator` for transient add/edit form state, photo loading, and persistence; slimmed `RootTabsView` to `RecipesView()` with no recipe dependency injection.
- Applies code-review hardening: synchronous `load(from:)` on edit sheet init, save reentrancy guard with `pendingRecipe`/`isSaving`, and explicit `Task { @MainActor in }` for async work.

## Test plan
- [x] `xcodebuild` build succeeded (iPhone 17 Pro simulator)
- [x] `UnitTestsPlan` — 25 tests, 0 failures
- [ ] Manual smoke — Recipes tab: empty state, add/edit/delete, photo attach, list refresh via `@Query`
- [ ] Manual smoke — Menu tab still generates with ≥7 recipes (no regression)
- [ ] Verify accessibility IDs unchanged (`recipesList`, `saveRecipeButton`, etc.)


Made with [Cursor](https://cursor.com)