### PR TITLE
test(helpers): cover MenuGenerator, DaySelectionStorage, and MenuPersistence

### DIFF
--- a/Tests/DaySelectionStorageTests.swift
+++ b/Tests/DaySelectionStorageTests.swift
@@ -1,0 +1,82 @@
+//
+//  DaySelectionStorageTests.swift
+//  whattomake
+//
+
+@testable import ForkPlan
+import SwiftUI
+import Testing
+
+@Suite
+struct DaySelectionStorageTests {
+    @Test
+    func decodeEmptyStringReturnsEmptySet() {
+        #expect(DaySelectionStorage.decode("") == [])
+    }
+
+    @Test
+    func decodeCommaSeparatedDays() {
+        let decoded = DaySelectionStorage.decode("Mon,Wed,Fri")
+        #expect(decoded == ["Mon", "Wed", "Fri"])
+    }
+
+    @Test
+    func decodeFiltersInvalidTokens() {
+        let decoded = DaySelectionStorage.decode("Mon,BadDay,Sun")
+        #expect(decoded == ["Mon", "Sun"])
+    }
+
+    @Test
+    func decodeIgnoresEmptySegments() {
+        let decoded = DaySelectionStorage.decode("Mon,,Wed")
+        #expect(decoded == ["Mon", "Wed"])
+    }
+
+    @Test
+    func encodeOrdersDaysCanonically() {
+        let encoded = DaySelectionStorage.encode(["Wed", "Mon"])
+        #expect(encoded == "Mon,Wed")
+    }
+
+    @Test
+    func encodeEmptySetReturnsEmptyString() {
+        #expect(DaySelectionStorage.encode([]) == "")
+    }
+
+    @Test
+    func encodeDecodeRoundtripIsStable() {
+        let raw = "Mon,Wed,Fri"
+        let encoded = DaySelectionStorage.encode(DaySelectionStorage.decode(raw))
+        #expect(encoded == raw)
+    }
+
+    @Test
+    func orderedDaysReturnsCanonicalOrder() {
+        let ordered = DaySelectionStorage.orderedDays(from: ["Wed", "Mon"])
+        #expect(ordered == ["Mon", "Wed"])
+    }
+
+    @Test
+    func orderedDaysReturnsEmptyArrayForEmptySet() {
+        #expect(DaySelectionStorage.orderedDays(from: []) == [])
+    }
+
+    @Test
+    func toggleBindingEncodesSelection() {
+        var raw = DaySelectionStorage.defaultValue
+        let binding = Binding(
+            get: { raw },
+            set: { raw = $0 }
+        )
+        let monToggle = DaySelectionStorage.toggleBinding(for: "Mon", raw: binding)
+        monToggle.wrappedValue = true
+        #expect(raw == "Mon")
+
+        let wedToggle = DaySelectionStorage.toggleBinding(for: "Wed", raw: binding)
+        wedToggle.wrappedValue = true
+        #expect(raw == "Mon,Wed")
+
+        monToggle.wrappedValue = false
+        #expect(raw == "Wed")
+    }
+}

--- a/Tests/MenuGeneratorTests.swift
+++ b/Tests/MenuGeneratorTests.swift
@@ -1,0 +1,68 @@
+//
+//  MenuGeneratorTests.swift
+//  whattomake
+//
+
+@testable import ForkPlan
+import Testing
+
+@MainActor
+@Suite
+struct MenuGeneratorTests {
+    @Test
+    func selectReturnsAtMostDayCount() {
+        let recipes = (1...10).map { Recipe(name: "Recipe \($0)") }
+        let days = ["Mon", "Wed", "Fri"]
+        let selected = MenuGenerator.select(from: recipes, forDays: days)
+        #expect(selected.count == days.count)
+    }
+
+    @Test
+    func selectReturnsCountMinOfRecipesAndDays() {
+        let recipes = (1...3).map { Recipe(name: "Recipe \($0)") }
+        let days = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+        let selected = MenuGenerator.select(from: recipes, forDays: days)
+        #expect(selected.count == recipes.count)
+    }
+
+    @Test
+    func selectReturnsMembersOfInputArray() {
+        let recipes = (1...5).map { Recipe(name: "Recipe \($0)") }
+        let days = ["Mon", "Wed"]
+        let selected = MenuGenerator.select(from: recipes, forDays: days)
+        let inputNames = Set(recipes.map(\.name))
+        for recipe in selected {
+            #expect(inputNames.contains(recipe.name))
+        }
+    }
+
+    @Test
+    func selectReturnsNoDuplicateRecipes() {
+        let recipes = (1...10).map { Recipe(name: "Recipe \($0)") }
+        let days = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+        let selected = MenuGenerator.select(from: recipes, forDays: days)
+        let names = selected.map(\.name)
+        #expect(Set(names).count == names.count)
+    }
+
+    @Test
+    func selectWithEmptyDaysReturnsEmpty() {
+        let recipes = [Recipe(name: "Recipe 1")]
+        let selected = MenuGenerator.select(from: recipes, forDays: [])
+        #expect(selected.isEmpty)
+    }
+
+    @Test
+    func selectWithEmptyRecipesReturnsEmpty() {
+        let selected = MenuGenerator.select(from: [], forDays: ["Mon", "Wed"])
+        #expect(selected.isEmpty)
+    }
+
+    @Test
+    func selectWithMoreDaysThanRecipesReturnsAllRecipes() {
+        let recipes = (1...3).map { Recipe(name: "Recipe \($0)") }
+        let days = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+        let selected = MenuGenerator.select(from: recipes, forDays: days)
+        #expect(selected.count == recipes.count)
+    }
+}

--- a/Tests/MenuPersistenceTests.swift
+++ b/Tests/MenuPersistenceTests.swift
@@ -1,0 +1,119 @@
+//
+//  MenuPersistenceTests.swift
+//  whattomake
+//
+
+@testable import ForkPlan
+import Foundation
+import SwiftData
+import Testing
+
+@MainActor
+@Suite
+struct MenuPersistenceTests {
+    @Test
+    func replaceMenuInsertsIntoEmptyStore() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let recipes = try seedRecipes(in: context, count: 3)
+
+        let menu = Menu(days: ["Mon"], recipes: [recipes[0]])
+        try MenuPersistence.replaceMenu(with: menu, in: context)
+
+        let stored = try context.fetch(FetchDescriptor<Menu>())
+        #expect(stored.count == 1)
+        #expect(stored.first?.days == ["Mon"])
+    }
+
+    @Test
+    func replaceMenuDeletesExistingMenus() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let recipes = try seedRecipes(in: context, count: 3)
+        _ = try seedMenu(in: context, days: ["Mon"], recipes: [recipes[0]])
+        _ = try seedMenu(in: context, days: ["Tue"], recipes: [recipes[1]])
+        #expect(try context.fetch(FetchDescriptor<Menu>()).count == 2)
+
+        let replacement = Menu(days: ["Wed"], recipes: [recipes[2]])
+        try MenuPersistence.replaceMenu(with: replacement, in: context)
+
+        let remaining = try context.fetch(FetchDescriptor<Menu>())
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.days == ["Wed"])
+    }
+
+    @Test
+    func replaceMenuPersistsExpectedContent() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let recipes = try seedRecipes(in: context, count: 2)
+
+        let menu = Menu(days: ["Mon", "Wed"], recipes: Array(recipes.prefix(2)))
+        try MenuPersistence.replaceMenu(with: menu, in: context)
+
+        let stored = try context.fetch(FetchDescriptor<Menu>()).first
+        #expect(stored?.days == ["Mon", "Wed"])
+        #expect(Set(stored?.recipes.map(\.name) ?? []) == Set(recipes.prefix(2).map(\.name)))
+    }
+
+    @Test
+    func latestDescriptorReturnsNewestMenuFirst() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let recipes = try seedRecipes(in: context, count: 2)
+
+        _ = try seedMenu(
+            in: context,
+            days: ["Mon"],
+            recipes: [recipes[0]],
+            generatedDate: Date().addingTimeInterval(-3600)
+        )
+        _ = try seedMenu(
+            in: context,
+            days: ["Wed"],
+            recipes: [recipes[1]],
+            generatedDate: Date()
+        )
+
+        let latest = try context.fetch(Menu.latestDescriptor()).first
+        #expect(latest?.days == ["Wed"])
+    }
+
+    @Test
+    func replaceMenuBecomesLatestByGeneratedDate() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let recipes = try seedRecipes(in: context, count: 2)
+
+        _ = try seedMenu(
+            in: context,
+            days: ["Mon"],
+            recipes: [recipes[0]],
+            generatedDate: Date().addingTimeInterval(-3600)
+        )
+
+        let replacement = Menu(
+            generatedDate: Date(),
+            days: ["Wed"],
+            recipes: [recipes[1]]
+        )
+        try MenuPersistence.replaceMenu(with: replacement, in: context)
+
+        let latest = try context.fetch(Menu.latestDescriptor()).first
+        #expect(latest?.days == ["Wed"])
+    }
+
+    @Test
+    func replaceMenuDoesNotDeleteLinkedRecipes() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let recipes = try seedRecipes(in: context, count: 2)
+        _ = try seedMenu(in: context, days: ["Mon"], recipes: [recipes[0]])
+
+        let replacement = Menu(days: ["Wed"], recipes: [recipes[1]])
+        try MenuPersistence.replaceMenu(with: replacement, in: context)
+
+        let storedRecipes = try context.fetch(FetchDescriptor<Recipe>())
+        #expect(storedRecipes.count == 2)
+    }
+}

--- a/whattomake.xcodeproj/project.pbxproj
+++ b/whattomake.xcodeproj/project.pbxproj
@@ -28,6 +28,9 @@
 		3C0A00022E60A00100000002 /* SnapshotTestingSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00012E60A00100000001 /* SnapshotTestingSmokeTests.swift */; };
 		3C0A00112E60B00300000002 /* TestModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00102E60B00300000001 /* TestModelContainer.swift */; };
 		3C0A00132E60B00300000004 /* TestModelContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00122E60B00300000003 /* TestModelContainerTests.swift */; };
+		3C0A00212E60E00600000002 /* MenuGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00202E60E00600000001 /* MenuGeneratorTests.swift */; };
+		3C0A00232E60E00600000004 /* DaySelectionStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00222E60E00600000003 /* DaySelectionStorageTests.swift */; };
+		3C0A00252E60E00600000006 /* MenuPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00242E60E00600000005 /* MenuPersistenceTests.swift */; };
 		3C0A00162E60C00400000002 /* MenuEmptyStateCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00152E60C00400000001 /* MenuEmptyStateCopy.swift */; };
 		3C0A001C2E60D00500000005 /* AppStorageKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00182E60D00500000001 /* AppStorageKey.swift */; };
 		3C0A001D2E60D00500000006 /* DaySelectionStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00192E60D00500000002 /* DaySelectionStorage.swift */; };
@@ -72,6 +75,9 @@
 		3C0A00012E60A00100000001 /* SnapshotTestingSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTestingSmokeTests.swift; sourceTree = "<group>"; };
 		3C0A00102E60B00300000001 /* TestModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModelContainer.swift; sourceTree = "<group>"; };
 		3C0A00122E60B00300000003 /* TestModelContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModelContainerTests.swift; sourceTree = "<group>"; };
+		3C0A00202E60E00600000001 /* MenuGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuGeneratorTests.swift; sourceTree = "<group>"; };
+		3C0A00222E60E00600000003 /* DaySelectionStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaySelectionStorageTests.swift; sourceTree = "<group>"; };
+		3C0A00242E60E00600000005 /* MenuPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuPersistenceTests.swift; sourceTree = "<group>"; };
 		3C0A00152E60C00400000001 /* MenuEmptyStateCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuEmptyStateCopy.swift; sourceTree = "<group>"; };
 		3C0A00182E60D00500000001 /* AppStorageKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorageKey.swift; sourceTree = "<group>"; };
 		3C0A00192E60D00500000002 /* DaySelectionStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaySelectionStorage.swift; sourceTree = "<group>"; };
@@ -141,6 +147,9 @@
 		3B5E9E8B2AE07F9D00293473 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				3C0A00222E60E00600000003 /* DaySelectionStorageTests.swift */,
+				3C0A00202E60E00600000001 /* MenuGeneratorTests.swift */,
+				3C0A00242E60E00600000005 /* MenuPersistenceTests.swift */,
 				3C0A00012E60A00100000001 /* SnapshotTestingSmokeTests.swift */,
 				3C0A00122E60B00300000003 /* TestModelContainerTests.swift */,
 				3C0A00142E60B00300000005 /* Fixtures */,
@@ -364,6 +373,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C0A00232E60E00600000004 /* DaySelectionStorageTests.swift in Sources */,
+				3C0A00212E60E00600000002 /* MenuGeneratorTests.swift in Sources */,
+				3C0A00252E60E00600000006 /* MenuPersistenceTests.swift in Sources */,
 				3C0A00022E60A00100000002 /* SnapshotTestingSmokeTests.swift in Sources */,
 				3C0A00112E60B00300000002 /* TestModelContainer.swift in Sources */,
 				3C0A00132E60B00300000004 /* TestModelContainerTests.swift in Sources */,


### PR DESCRIPTION
Story 1.5 restores automated unit test coverage for the pure menu helpers extracted in Story 1.2. After Story 1.4 removed legacy use case and repository tests, only smoke and fixture suites remained; this PR adds focused tests for `MenuGenerator`, `DaySelectionStorage`, and `MenuPersistence` without changing production behavior.

`MenuGeneratorTests` asserts shuffle-based selection invariants (count, membership, uniqueness, and empty-input cases). `DaySelectionStorageTests` covers encode/decode, canonical ordering, toggle bindings, and empty-set handling. `MenuPersistenceTests` uses `makeTestContainer()` to verify delete-before-insert replacement, persisted content, `latestDescriptor` sort order, and recipe survival after menu replacement.

All three suites are registered in the `whattomakeTests` target only. `UnitTestsPlan` passes with 25 tests across 5 suites on iPhone 17 Pro.

Made with [Cursor](https://cursor.com)