### PR TITLE
test: add FR6 menu persistence integration tests (Story 2.4)

### DIFF
--- a/Tests/Fixtures/TestModelContainer.swift
+++ b/Tests/Fixtures/TestModelContainer.swift
@@ -19,6 +19,37 @@ func makeTestContainer() throws -> ModelContainer {
     )
 }
 
+/// Creates a unique temporary directory for disk-backed SwiftData tests (FR6 relaunch simulation).
+///
+/// Returns the `.store` file URL inside a UUID-named temp directory. The caller **must**
+/// remove the parent directory in `defer` after the test completes:
+/// `try? FileManager.default.removeItem(at: storeURL.deletingLastPathComponent())`.
+///
+/// - Throws: If the temp directory cannot be created.
+@MainActor
+func makePersistentTestStoreURL() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+        .appending(path: "ForkPlanTestStore-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory.appending(path: "TestStore.store")
+}
+
+/// Opens a disk-backed `ModelContainer` at `storeURL` — mirrors production persistence, not in-memory.
+///
+/// Use the same `storeURL` across container instances to simulate app relaunch after the first
+/// container is deallocated.
+///
+/// - Parameter storeURL: Store file URL from ``makePersistentTestStoreURL()``.
+/// - Throws: If `ModelContainer` initialization fails.
+@MainActor
+func makePersistentTestContainer(storeURL: URL) throws -> ModelContainer {
+    let configuration = ModelConfiguration(url: storeURL)
+    return try ModelContainer(
+        for: Recipe.self, Menu.self,
+        configurations: configuration
+    )
+}
+
 /// Seeds recipes into the context and saves.
 ///
 /// - Parameters:

--- a/Tests/MenuPersistenceIntegrationTests.swift
+++ b/Tests/MenuPersistenceIntegrationTests.swift
@@ -1,0 +1,88 @@
+//
+//  MenuPersistenceIntegrationTests.swift
+//  whattomake
+//
+
+@testable import ForkPlan
+import Foundation
+import SwiftData
+import Testing
+
+@MainActor
+@Suite
+struct MenuPersistenceIntegrationTests {
+    @Test
+    func menuSurvivesSimulatedRelaunch() throws {
+        let storeURL = try makePersistentTestStoreURL()
+        defer { try? FileManager.default.removeItem(at: storeURL.deletingLastPathComponent()) }
+
+        let expectedDays = ["Mon", "Wed", "Fri"]
+        var expectedRecipeNames: [String] = []
+
+        do {
+            let container = try makePersistentTestContainer(storeURL: storeURL)
+            let context = container.mainContext
+            let recipes = try seedRecipes(in: context, count: 3)
+            expectedRecipeNames = Array(recipes.prefix(3).map(\.name))
+            let menu = Menu(days: expectedDays, recipes: Array(recipes.prefix(3)))
+            try MenuPersistence.replaceMenu(with: menu, in: context)
+        }
+
+        let relaunchContainer = try makePersistentTestContainer(storeURL: storeURL)
+        let relaunchContext = relaunchContainer.mainContext
+
+        let latest = try relaunchContext.fetch(Menu.latestDescriptor()).first
+        #expect(latest?.days == expectedDays)
+        #expect(latest?.recipeNames == expectedRecipeNames)
+        #expect(try relaunchContext.fetch(FetchDescriptor<Menu>()).count == 1)
+        #expect(try relaunchContext.fetch(FetchDescriptor<Recipe>()).count == 3)
+    }
+
+    @Test
+    func regenerateReplacesMenuAfterRelaunch() throws {
+        let storeURL = try makePersistentTestStoreURL()
+        defer { try? FileManager.default.removeItem(at: storeURL.deletingLastPathComponent()) }
+
+        var expectedRegenerateRecipeNames: [String] = []
+
+        do {
+            let container = try makePersistentTestContainer(storeURL: storeURL)
+            let context = container.mainContext
+            let recipes = try seedRecipes(in: context, count: 3)
+            expectedRegenerateRecipeNames = [recipes[1].name, recipes[2].name]
+            let menuOne = Menu(days: ["Mon"], recipes: [recipes[0]])
+            try MenuPersistence.replaceMenu(with: menuOne, in: context)
+        }
+
+        do {
+            let container = try makePersistentTestContainer(storeURL: storeURL)
+            let context = container.mainContext
+            let latest = try context.fetch(Menu.latestDescriptor()).first
+            #expect(latest?.days == ["Mon"])
+        }
+
+        do {
+            let container = try makePersistentTestContainer(storeURL: storeURL)
+            let context = container.mainContext
+            let recipes = try context.fetch(FetchDescriptor<Recipe>())
+            let menuTwoRecipes = expectedRegenerateRecipeNames.compactMap { name in
+                recipes.first { $0.name == name }
+            }
+            #expect(menuTwoRecipes.count == expectedRegenerateRecipeNames.count)
+            let menuTwo = Menu(days: ["Wed", "Fri"], recipes: menuTwoRecipes)
+            try MenuPersistence.replaceMenu(with: menuTwo, in: context)
+        }
+
+        let finalContainer = try makePersistentTestContainer(storeURL: storeURL)
+        let finalContext = finalContainer.mainContext
+
+        let allMenus = try finalContext.fetch(FetchDescriptor<Menu>())
+        #expect(allMenus.count == 1)
+
+        let latest = try finalContext.fetch(Menu.latestDescriptor()).first
+        #expect(latest?.days == ["Wed", "Fri"])
+        #expect(latest?.recipeNames == expectedRegenerateRecipeNames)
+        #expect(allMenus.contains { $0.days == ["Mon"] } == false)
+        #expect(try finalContext.fetch(FetchDescriptor<Recipe>()).count == 3)
+    }
+}

--- a/whattomake.xcodeproj/project.pbxproj
+++ b/whattomake.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		3C0A00212E60E00600000002 /* MenuGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00202E60E00600000001 /* MenuGeneratorTests.swift */; };
 		3C0A00232E60E00600000004 /* DaySelectionStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00222E60E00600000003 /* DaySelectionStorageTests.swift */; };
 		3C0A00252E60E00600000006 /* MenuPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00242E60E00600000005 /* MenuPersistenceTests.swift */; };
+		3C0A002D2E60F00800000002 /* MenuPersistenceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A002C2E60F00800000001 /* MenuPersistenceIntegrationTests.swift */; };
 		3C0A00272E60F00700000002 /* SnapshotTestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00262E60F00700000001 /* SnapshotTestConfiguration.swift */; };
 		3C0A00292E60F00700000004 /* RecipeSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A00282E60F00700000003 /* RecipeSnapshotTests.swift */; };
 		3C0A002B2E60F00700000006 /* MenuSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0A002A2E60F00700000005 /* MenuSnapshotTests.swift */; };
@@ -85,6 +86,7 @@
 		3C0A00202E60E00600000001 /* MenuGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuGeneratorTests.swift; sourceTree = "<group>"; };
 		3C0A00222E60E00600000003 /* DaySelectionStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaySelectionStorageTests.swift; sourceTree = "<group>"; };
 		3C0A00242E60E00600000005 /* MenuPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuPersistenceTests.swift; sourceTree = "<group>"; };
+		3C0A002C2E60F00800000001 /* MenuPersistenceIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuPersistenceIntegrationTests.swift; sourceTree = "<group>"; };
 		3C0A00262E60F00700000001 /* SnapshotTestConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTestConfiguration.swift; sourceTree = "<group>"; };
 		3C0A00282E60F00700000003 /* RecipeSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeSnapshotTests.swift; sourceTree = "<group>"; };
 		3C0A002A2E60F00700000005 /* MenuSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuSnapshotTests.swift; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 				3C0A00222E60E00600000003 /* DaySelectionStorageTests.swift */,
 				3C0A00202E60E00600000001 /* MenuGeneratorTests.swift */,
 				3C0A00242E60E00600000005 /* MenuPersistenceTests.swift */,
+				3C0A002C2E60F00800000001 /* MenuPersistenceIntegrationTests.swift */,
 				3C0A002A2E60F00700000005 /* MenuSnapshotTests.swift */,
 				3C0A00282E60F00700000003 /* RecipeSnapshotTests.swift */,
 				3C0A00012E60A00100000001 /* SnapshotTestingSmokeTests.swift */,
@@ -393,6 +396,7 @@
 				3C0A00232E60E00600000004 /* DaySelectionStorageTests.swift in Sources */,
 				3C0A00212E60E00600000002 /* MenuGeneratorTests.swift in Sources */,
 				3C0A00252E60E00600000006 /* MenuPersistenceTests.swift in Sources */,
+				3C0A002D2E60F00800000002 /* MenuPersistenceIntegrationTests.swift in Sources */,
 				3C0A002B2E60F00700000006 /* MenuSnapshotTests.swift in Sources */,
 				3C0A00292E60F00700000004 /* RecipeSnapshotTests.swift in Sources */,
 				3C0A00022E60A00100000002 /* SnapshotTestingSmokeTests.swift in Sources */,


### PR DESCRIPTION
Story 1.2 verified menu persistence (FR6) with manual kill/relaunch smoke only. This change closes the deferred Epic 2 gap with automated integration tests that use a disk-backed SwiftData store and a new `ModelContainer` instance to simulate app relaunch.

`TestModelContainer.swift` gains `makePersistentTestStoreURL()` and `makePersistentTestContainer(storeURL:)` helpers alongside the existing in-memory fixture. `MenuPersistenceIntegrationTests` exercises the production write path via `MenuPersistence.replaceMenu` and asserts that menus survive container deallocation, that recipe names and counts persist, and that regenerate performs delete-before-insert across relaunch cycles.

No production code changes. Existing same-session unit tests in `MenuPersistenceTests` are unchanged.

Made with [Cursor](https://cursor.com)